### PR TITLE
fix(ci): handle fork PRs and edge cases in workflows

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,7 +1,10 @@
 name: Auto Assign
 
 on:
-  pull_request:
+  # Use pull_request_target for PRs to have write permissions on fork PRs
+  # This is safe because we don't checkout or execute any code from the PR
+  # We only use GitHub API to assign users and add labels
+  pull_request_target:
     types: [opened, ready_for_review]
   issues:
     types: [opened]
@@ -14,7 +17,7 @@ jobs:
   assign:
     name: Auto-assign issues and PRs
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false || github.event_name == 'issues'
     steps:
       - name: Auto-assign issue or PR to author
         uses: actions/github-script@v7
@@ -43,7 +46,7 @@ jobs:
   label-pr:
     name: Label pull requests
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -74,6 +74,8 @@ jobs:
   nancy:
     name: Dependency Security Scan
     runs-on: ubuntu-latest
+    # Skip for fork PRs as secrets are not available
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     continue-on-error: true  # Don't fail if nancy has issues
     steps:
       - name: Check out code
@@ -96,21 +98,30 @@ jobs:
           OSSI_TOKEN: ${{ secrets.SONATATYPE_OSSI_TOKEN }}
           OSSI_USERNAME: ${{ vars.SONATATYPE_OSSI_USERNAME }}
         run: |
-          [ -z "$OSSI_TOKEN" ] && echo "OSSI_TOKEN is EMPTY"
-          [ -z "$OSSI_USERNAME" ] && echo "OSSI_USERNAME is EMPTY"
+          # Skip if credentials are not available (e.g., fork PRs)
+          if [ -z "$OSSI_TOKEN" ] || [ -z "$OSSI_USERNAME" ]; then
+            echo "⚠️ OSSI credentials not available, skipping Nancy scan"
+            echo "This is expected for fork PRs where secrets are not accessible"
+            exit 0
+          fi
           go list -json -deps ./... | nancy sleuth --token "$OSSI_TOKEN" --username "$OSSI_USERNAME"
 
   secret-scan:
     name: Secret Scanning
     runs-on: ubuntu-latest
+    # Skip on push events where before/after are the same (initial commit, force push to same SHA)
+    if: github.event_name != 'push' || github.event.before != github.event.after
     continue-on-error: true  # Don't fail on scanning issues
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch full history for proper diff
 
       - name: Run Trufflehog
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: main
-          head: HEAD
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          extra_args: --only-verified


### PR DESCRIPTION
## Description

Fix three workflow issues that cause systematic failures on fork PRs and edge cases.

## Type of Change

- [x] 🔧 CI/CD improvements

## Issues Fixed

### 1. Nancy Job - 401 Unauthorized on Fork PRs
**Workflow:** `security.yml`
**Error:** `Error: An error occurred: [401 Unauthorized] error accessing OSS Index`
**Root Cause:** Fork PRs don't have access to repository secrets (`OSSI_TOKEN`, `OSSI_USERNAME`)

**Fix:**
- Add job-level condition to skip for fork PRs: `github.event.pull_request.head.repo.full_name == github.repository`
- Add runtime check to gracefully exit when credentials unavailable

### 2. Trufflehog - BASE and HEAD are the same
**Workflow:** `security.yml`
**Error:** `BASE and HEAD commits are the same. TruffleHog won't scan anything.`
**Root Cause:** On certain push events (force push to same SHA, initial commit), before/after are identical

**Fix:**
- Add condition to skip when `github.event.before == github.event.after`
- Use proper base/head refs for both push and PR events
- Add `fetch-depth: 0` for full git history
- Add `--only-verified` flag to reduce false positives

### 3. Auto-assign - Resource not accessible by integration
**Workflow:** `auto-assign.yml`
**Error:** `HttpError: Resource not accessible by integration`
**Root Cause:** `pull_request` event from forks runs with read-only permissions

**Fix:**
- Change from `pull_request` to `pull_request_target` event
- This gives write permissions for fork PRs
- **Security Note:** This is safe because we only use GitHub API to assign/label, we don't checkout or execute any code from the PR

## Testing

- [x] `actionlint` passes on modified workflows
- [ ] Verify Nancy skips gracefully on fork PRs
- [ ] Verify Trufflehog handles edge cases
- [ ] Verify auto-assign works on fork PRs

## Files Modified

| File | Changes |
|------|---------|
| `.github/workflows/security.yml` | Nancy + Trufflehog fixes |
| `.github/workflows/auto-assign.yml` | pull_request_target event |

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] **Commit messages follow Conventional Commits format**

## Security Considerations

The `pull_request_target` change in auto-assign.yml is safe because:
1. We don't checkout any code from the PR
2. We only use GitHub API to assign users and add labels
3. No secrets are exposed to PR code execution

References:
- [GitHub Actions: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
- [Accessing secrets from forks safely](https://michaelheap.com/access-secrets-from-forks/)