### PR TITLE
feat: run commands with app authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A GitHub CLI extension that enables GitHub App authentication for Git operations
 - **Encrypted Storage**: Private keys stored in OS-native keyring (Keychain, Credential Manager, Secret Service)
 - **Pattern Routing**: Configure different apps for different repository URL prefixes
 - **Git Integration**: Git credential helper protocol support
+- **GitHub CLI Integration**: Run `gh` and other commands with short-lived credentials
 - **Token Caching**: In-memory caching of installation tokens (55-min TTL)
 - **Multi-Host**: GitHub.com, GitHub Enterprise, and Bitbucket Server support
 - **CI/CD Ready**: Environment variable support (`GH_APP_PRIVATE_KEY`)
@@ -92,7 +93,19 @@ gh app-auth test --repo github.com/myorg/private-repo
 
 # Use git normally - now uses GitHub App authentication
 git clone https://github.com/myorg/private-repo.git
+
+# Run gh with a short-lived token for the current repository
+gh app-auth exec -- gh pr list
+
+# Run gh outside a repository by specifying the authentication target
+gh app-auth exec --repo github.com/myorg/private-repo -- \
+  gh api repos/{owner}/{repo}
 ```
+
+`exec` mints a token on demand and exposes it only to the child process through
+`GH_TOKEN` (or `GH_ENTERPRISE_TOKEN` for GitHub Enterprise Server). It also sets
+`GH_HOST` and `GH_REPO`, so repository-aware `gh` commands work outside a Git
+checkout. No token is printed or persisted by this command.
 
 ## URL Prefix Routing
 
@@ -116,6 +129,7 @@ See [URL Prefix Routing Guide](docs/PATTERN_ROUTING.md) for detailed examples.
 - `gh app-auth list` - List configured credentials (`--verify-keys` to check accessibility)
 - `gh app-auth remove` - Remove GitHub App (`--app-id`) or PAT (`--pat-name`) configuration
 - `gh app-auth test` - Test authentication for a repository
+- `gh app-auth exec` - Run a command with short-lived credentials for a repository
 - `gh app-auth scope` - Fetch and display GitHub App installation scope (which repos the app can access)
 - `gh app-auth config` - Show configuration file location (`--path`) or content (`--show`)
 - `gh app-auth gitconfig` - Manage git credential helper configuration

--- a/README.md
+++ b/README.md
@@ -100,12 +100,21 @@ gh app-auth exec -- gh pr list
 # Run gh outside a repository by specifying the authentication target
 gh app-auth exec --repo github.com/myorg/private-repo -- \
   gh api repos/{owner}/{repo}
+
+# Run an API command that is not scoped to one repository
+gh app-auth exec \
+  --app-id 123456 \
+  --installation-id 789012 \
+  -- gh api /installation/repositories
 ```
 
 `exec` mints a token on demand and exposes it only to the child process through
-`GH_TOKEN` (or `GH_ENTERPRISE_TOKEN` for GitHub Enterprise Server). It also sets
-`GH_HOST` and `GH_REPO`, so repository-aware `gh` commands work outside a Git
-checkout. No token is printed or persisted by this command.
+`GH_TOKEN` (or `GH_ENTERPRISE_TOKEN` for GitHub Enterprise Server). Repository
+routing sets both `GH_HOST` and `GH_REPO`; selecting a configured App with
+`--app-id` or `--installation-id` sets `GH_HOST` without inventing a repository
+scope. Use both IDs to disambiguate Apps configured for multiple installations.
+PAT selection remains repository-based. No token is printed or persisted by
+this command.
 
 ## URL Prefix Routing
 
@@ -129,7 +138,7 @@ See [URL Prefix Routing Guide](docs/PATTERN_ROUTING.md) for detailed examples.
 - `gh app-auth list` - List configured credentials (`--verify-keys` to check accessibility)
 - `gh app-auth remove` - Remove GitHub App (`--app-id`) or PAT (`--pat-name`) configuration
 - `gh app-auth test` - Test authentication for a repository
-- `gh app-auth exec` - Run a command with short-lived credentials for a repository
+- `gh app-auth exec` - Run a command with short-lived credentials selected by repository, App ID, or installation ID
 - `gh app-auth scope` - Fetch and display GitHub App installation scope (which repos the app can access)
 - `gh app-auth config` - Show configuration file location (`--path`) or content (`--show`)
 - `gh app-auth gitconfig` - Manage git credential helper configuration

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/AmadeusITGroup/gh-app-auth/pkg/auth"
+	"github.com/cli/go-gh/v2/pkg/repository"
+	"github.com/spf13/cobra"
+)
+
+type execTokenResolver func(string) (string, error)
+
+type execCommandRunner func(
+	context.Context,
+	string,
+	[]string,
+	[]string,
+	io.Reader,
+	io.Writer,
+	io.Writer,
+) error
+
+func NewExecCmd() *cobra.Command {
+	return newExecCmd(resolveExecToken, runExecCommand)
+}
+
+func newExecCmd(resolveToken execTokenResolver, runCommand execCommandRunner) *cobra.Command {
+	var repoFlag string
+
+	cmd := &cobra.Command{
+		Use:   "exec [--repo <repository>] -- <command> [args...]",
+		Short: "Run a command with GitHub App authentication",
+		Long: `Run a command with a short-lived token from the GitHub App or PAT
+configured for a repository. The token is exposed only to the child process
+through the environment and is never printed by gh-app-auth.`,
+		Example: `  # Call the GitHub API for the current repository
+  gh app-auth exec -- gh api repos/{owner}/{repo}
+
+  # Run a gh command outside a repository
+  gh app-auth exec --repo github.com/myorg/myrepo -- gh pr list`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			repoURL, err := determineRepositoryURL(repoFlag)
+			if err != nil {
+				return err
+			}
+
+			repo, err := repository.Parse(repoURL)
+			if err != nil {
+				return fmt.Errorf("failed to parse repository %q: %w", repoURL, err)
+			}
+			canonicalRepo := fmt.Sprintf("%s/%s/%s", repo.Host, repo.Owner, repo.Name)
+
+			token, err := resolveToken(canonicalRepo)
+			if err != nil {
+				return err
+			}
+
+			env := execEnvironment(os.Environ(), repo, token)
+			return runCommand(
+				cmd.Context(),
+				args[0],
+				args[1:],
+				env,
+				cmd.InOrStdin(),
+				cmd.OutOrStdout(),
+				cmd.ErrOrStderr(),
+			)
+		},
+	}
+
+	cmd.Flags().StringVarP(&repoFlag, "repo", "R", "", "Repository to authenticate for (default: current repository)")
+
+	return cmd
+}
+
+func resolveExecToken(repoURL string) (string, error) {
+	cfg, err := loadCredentialConfig()
+	if err != nil {
+		return "", err
+	}
+
+	matchedApp, matchedPAT, err := findMatchingCredential(cfg, repoURL)
+	if err != nil {
+		return "", err
+	}
+	if matchedApp == nil && matchedPAT == nil {
+		return "", fmt.Errorf("no credential configured for %s; run 'gh app-auth setup' first", repoURL)
+	}
+
+	if matchedPAT != nil {
+		secretManager, err := newDefaultSecretsManager()
+		if err != nil {
+			return "", err
+		}
+		token, err := matchedPAT.GetPAT(secretManager)
+		if err != nil {
+			return "", fmt.Errorf("failed to get PAT: %w", err)
+		}
+		return token, nil
+	}
+
+	token, _, err := auth.NewAuthenticator().GetCredentials(matchedApp, repoURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to get GitHub App credentials: %w", err)
+	}
+	return token, nil
+}
+
+func execEnvironment(current []string, repo repository.Repository, token string) []string {
+	blocked := map[string]struct{}{
+		"GH_TOKEN":                {},
+		"GITHUB_TOKEN":            {},
+		"GH_ENTERPRISE_TOKEN":     {},
+		"GITHUB_ENTERPRISE_TOKEN": {},
+		"GH_HOST":                 {},
+		"GH_REPO":                 {},
+	}
+
+	env := make([]string, 0, len(current)+3)
+	for _, entry := range current {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, found := blocked[key]; !found {
+			env = append(env, entry)
+		}
+	}
+
+	tokenVariable := "GH_ENTERPRISE_TOKEN"
+	if repo.Host == "github.com" || strings.HasSuffix(repo.Host, ".ghe.com") {
+		tokenVariable = "GH_TOKEN"
+	}
+
+	return append(
+		env,
+		tokenVariable+"="+token,
+		"GH_HOST="+repo.Host,
+		fmt.Sprintf("GH_REPO=%s/%s/%s", repo.Host, repo.Owner, repo.Name),
+	)
+}
+
+func runExecCommand(
+	ctx context.Context,
+	name string,
+	args []string,
+	env []string,
+	stdin io.Reader,
+	stdout io.Writer,
+	stderr io.Writer,
+) error {
+	child := exec.CommandContext(ctx, name, args...)
+	child.Env = env
+	child.Stdin = stdin
+	child.Stdout = stdout
+	child.Stderr = stderr
+	return child.Run()
+}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -62,7 +62,7 @@ through the environment and is never printed by gh-app-auth.`,
 			}
 
 			env := execEnvironment(os.Environ(), repo, token)
-			return runCommand(
+			err = runCommand(
 				cmd.Context(),
 				args[0],
 				args[1:],
@@ -71,6 +71,11 @@ through the environment and is never printed by gh-app-auth.`,
 				cmd.OutOrStdout(),
 				cmd.ErrOrStderr(),
 			)
+			if err != nil {
+				cmd.Root().SilenceErrors = true
+				cmd.Root().SilenceUsage = true
+			}
+			return err
 		},
 	}
 
@@ -152,6 +157,7 @@ func runExecCommand(
 	stdout io.Writer,
 	stderr io.Writer,
 ) error {
+	// #nosec G204 -- The user explicitly selects the command, which is executed directly without a shell.
 	child := exec.CommandContext(ctx, name, args...)
 	child.Env = env
 	child.Stdin = stdin

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -9,11 +9,25 @@ import (
 	"strings"
 
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/auth"
+	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
+	"github.com/AmadeusITGroup/gh-app-auth/pkg/matcher"
 	"github.com/cli/go-gh/v2/pkg/repository"
 	"github.com/spf13/cobra"
 )
 
-type execTokenResolver func(string) (string, error)
+type execCredentialRequest struct {
+	Repository     string
+	AppID          int64
+	InstallationID int64
+}
+
+type execCredential struct {
+	Token      string
+	Host       string
+	Repository string
+}
+
+type execCredentialResolver func(execCredentialRequest) (execCredential, error)
 
 type execCommandRunner func(
 	context.Context,
@@ -26,42 +40,51 @@ type execCommandRunner func(
 ) error
 
 func NewExecCmd() *cobra.Command {
-	return newExecCmd(resolveExecToken, runExecCommand)
+	return newExecCmd(resolveExecCredential, runExecCommand)
 }
 
-func newExecCmd(resolveToken execTokenResolver, runCommand execCommandRunner) *cobra.Command {
-	var repoFlag string
+func newExecCmd(resolveCredential execCredentialResolver, runCommand execCommandRunner) *cobra.Command {
+	var (
+		repoFlag           string
+		appIDFlag          int64
+		installationIDFlag int64
+	)
 
 	cmd := &cobra.Command{
-		Use:   "exec [--repo <repository>] -- <command> [args...]",
-		Short: "Run a command with GitHub App authentication",
-		Long: `Run a command with a short-lived token from the GitHub App or PAT
-configured for a repository. The token is exposed only to the child process
-through the environment and is never printed by gh-app-auth.`,
+		Use:   "exec [flags] -- <command> [args...]",
+		Short: "Run a command with managed GitHub authentication",
+		Long: `Run a command with a short-lived token from a configured GitHub App
+or PAT. Select credentials by repository, App ID, or installation ID. The token
+is exposed only to the child process through the environment and is never
+printed by gh-app-auth.`,
 		Example: `  # Call the GitHub API for the current repository
   gh app-auth exec -- gh api repos/{owner}/{repo}
 
   # Run a gh command outside a repository
-  gh app-auth exec --repo github.com/myorg/myrepo -- gh pr list`,
+  gh app-auth exec --repo github.com/myorg/myrepo -- gh pr list
+
+  # Run a repository-independent API command as a configured App installation
+  gh app-auth exec --app-id 123456 --installation-id 789012 -- gh api /installation/repositories`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			repoURL, err := determineRepositoryURL(repoFlag)
+			if cmd.Flags().Changed("app-id") && appIDFlag <= 0 {
+				return fmt.Errorf("app ID must be positive")
+			}
+			if cmd.Flags().Changed("installation-id") && installationIDFlag <= 0 {
+				return fmt.Errorf("installation ID must be positive")
+			}
+
+			request, err := newExecCredentialRequest(repoFlag, appIDFlag, installationIDFlag)
 			if err != nil {
 				return err
 			}
 
-			repo, err := repository.Parse(repoURL)
-			if err != nil {
-				return fmt.Errorf("failed to parse repository %q: %w", repoURL, err)
-			}
-			canonicalRepo := fmt.Sprintf("%s/%s/%s", repo.Host, repo.Owner, repo.Name)
-
-			token, err := resolveToken(canonicalRepo)
+			credential, err := resolveCredential(request)
 			if err != nil {
 				return err
 			}
 
-			env := execEnvironment(os.Environ(), repo, token)
+			env := execEnvironment(os.Environ(), credential)
 			err = runCommand(
 				cmd.Context(),
 				args[0],
@@ -79,45 +102,253 @@ through the environment and is never printed by gh-app-auth.`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&repoFlag, "repo", "R", "", "Repository to authenticate for (default: current repository)")
+	cmd.Flags().StringVarP(
+		&repoFlag,
+		"repo",
+		"R",
+		"",
+		"Repository to authenticate for (default: current repository unless an ID selector is used)",
+	)
+	cmd.Flags().Int64Var(&appIDFlag, "app-id", 0, "Configured GitHub App ID to authenticate with")
+	cmd.Flags().Int64Var(&installationIDFlag, "installation-id", 0, "GitHub App installation ID to authenticate with")
 
 	return cmd
 }
 
-func resolveExecToken(repoURL string) (string, error) {
-	cfg, err := loadCredentialConfig()
-	if err != nil {
-		return "", err
+func newExecCredentialRequest(repoURL string, appID, installationID int64) (execCredentialRequest, error) {
+	if appID < 0 {
+		return execCredentialRequest{}, fmt.Errorf("app ID must be positive")
+	}
+	if installationID < 0 {
+		return execCredentialRequest{}, fmt.Errorf("installation ID must be positive")
 	}
 
+	if repoURL == "" && appID == 0 && installationID == 0 {
+		var err error
+		repoURL, err = determineRepositoryURL("")
+		if err != nil {
+			return execCredentialRequest{}, err
+		}
+	}
+
+	if repoURL != "" {
+		repo, err := repository.Parse(repoURL)
+		if err != nil {
+			return execCredentialRequest{}, fmt.Errorf("failed to parse repository %q: %w", repoURL, err)
+		}
+		repoURL = fmt.Sprintf("%s/%s/%s", repo.Host, repo.Owner, repo.Name)
+	}
+
+	return execCredentialRequest{
+		Repository:     repoURL,
+		AppID:          appID,
+		InstallationID: installationID,
+	}, nil
+}
+
+func resolveExecCredential(request execCredentialRequest) (execCredential, error) {
+	cfg, err := loadCredentialConfig()
+	if err != nil {
+		return execCredential{}, err
+	}
+
+	if request.AppID == 0 && request.InstallationID == 0 {
+		return resolveRepositoryCredential(cfg, request.Repository)
+	}
+
+	selectedApp, err := selectExecApp(cfg, request)
+	if err != nil {
+		return execCredential{}, err
+	}
+
+	app := *selectedApp
+	if request.InstallationID != 0 {
+		app.InstallationID = request.InstallationID
+	}
+
+	host, tokenTarget, err := execCredentialTarget(app, request.Repository)
+	if err != nil {
+		return execCredential{}, err
+	}
+
+	token, _, err := auth.NewAuthenticator().GetCredentials(&app, tokenTarget)
+	if err != nil {
+		return execCredential{}, fmt.Errorf("failed to get GitHub App credentials: %w", err)
+	}
+
+	return execCredential{Token: token, Host: host, Repository: request.Repository}, nil
+}
+
+func execCredentialTarget(app config.GitHubApp, repoURL string) (string, string, error) {
+	if repoURL != "" {
+		repo, err := repository.Parse(repoURL)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to parse repository %q: %w", repoURL, err)
+		}
+		return repo.Host, repoURL, nil
+	}
+
+	if app.InstallationID == 0 {
+		return "", "", fmt.Errorf("selected GitHub App has no installation ID; use --installation-id or --repo")
+	}
+	host, err := inferExecHost(app.Patterns)
+	if err != nil {
+		return "", "", err
+	}
+	return host, host, nil
+}
+
+func resolveRepositoryCredential(cfg *config.Config, repoURL string) (execCredential, error) {
 	matchedApp, matchedPAT, err := findMatchingCredential(cfg, repoURL)
 	if err != nil {
-		return "", err
+		return execCredential{}, err
 	}
 	if matchedApp == nil && matchedPAT == nil {
-		return "", fmt.Errorf("no credential configured for %s; run 'gh app-auth setup' first", repoURL)
+		return execCredential{}, fmt.Errorf("no credential configured for %s; run 'gh app-auth setup' first", repoURL)
+	}
+
+	repo, err := repository.Parse(repoURL)
+	if err != nil {
+		return execCredential{}, fmt.Errorf("failed to parse repository %q: %w", repoURL, err)
 	}
 
 	if matchedPAT != nil {
-		secretManager, err := newDefaultSecretsManager()
-		if err != nil {
-			return "", err
+		secretManager, managerErr := newDefaultSecretsManager()
+		if managerErr != nil {
+			return execCredential{}, managerErr
 		}
-		token, err := matchedPAT.GetPAT(secretManager)
-		if err != nil {
-			return "", fmt.Errorf("failed to get PAT: %w", err)
+		token, tokenErr := matchedPAT.GetPAT(secretManager)
+		if tokenErr != nil {
+			return execCredential{}, fmt.Errorf("failed to get PAT: %w", tokenErr)
 		}
-		return token, nil
+		return execCredential{Token: token, Host: repo.Host, Repository: repoURL}, nil
 	}
 
 	token, _, err := auth.NewAuthenticator().GetCredentials(matchedApp, repoURL)
 	if err != nil {
-		return "", fmt.Errorf("failed to get GitHub App credentials: %w", err)
+		return execCredential{}, fmt.Errorf("failed to get GitHub App credentials: %w", err)
 	}
-	return token, nil
+	return execCredential{Token: token, Host: repo.Host, Repository: repoURL}, nil
 }
 
-func execEnvironment(current []string, repo repository.Repository, token string) []string {
+func selectExecApp(cfg *config.Config, request execCredentialRequest) (*config.GitHubApp, error) {
+	candidates := execAppCandidates(cfg.GitHubApps, request)
+	if len(candidates) == 0 {
+		return nil, execAppNotFoundError(request)
+	}
+	if len(candidates) == 1 {
+		return &candidates[0], nil
+	}
+
+	if request.Repository != "" {
+		matchedApp, err := matcher.NewMatcher(candidates).Match(request.Repository)
+		if err != nil {
+			return nil, fmt.Errorf("failed to match selected GitHub App to repository: %w", err)
+		}
+		if matchedApp != nil {
+			return matchedApp, nil
+		}
+	}
+
+	return nil, ambiguousExecAppError(request)
+}
+
+func execAppCandidates(apps []config.GitHubApp, request execCredentialRequest) []config.GitHubApp {
+	candidates := matchingExecApps(apps, request)
+	if request.AppID == 0 || request.InstallationID == 0 {
+		return candidates
+	}
+
+	exact := matchingExecInstallations(candidates, request.InstallationID)
+	if len(exact) > 0 {
+		return exact
+	}
+	return candidates
+}
+
+func matchingExecApps(apps []config.GitHubApp, request execCredentialRequest) []config.GitHubApp {
+	candidates := make([]config.GitHubApp, 0, len(apps))
+	for _, app := range apps {
+		if request.AppID != 0 && app.AppID != request.AppID {
+			continue
+		}
+		if request.AppID == 0 && request.InstallationID != 0 && app.InstallationID != request.InstallationID {
+			continue
+		}
+		candidates = append(candidates, app)
+	}
+	return candidates
+}
+
+func matchingExecInstallations(apps []config.GitHubApp, installationID int64) []config.GitHubApp {
+	matches := make([]config.GitHubApp, 0, len(apps))
+	for _, app := range apps {
+		if app.InstallationID == installationID {
+			matches = append(matches, app)
+		}
+	}
+	return matches
+}
+
+func execAppNotFoundError(request execCredentialRequest) error {
+	switch {
+	case request.AppID != 0 && request.InstallationID != 0:
+		return fmt.Errorf(
+			"no configured GitHub App matches app ID %d and installation ID %d",
+			request.AppID,
+			request.InstallationID,
+		)
+	case request.AppID != 0:
+		return fmt.Errorf("no configured GitHub App matches app ID %d", request.AppID)
+	default:
+		return fmt.Errorf("no configured GitHub App matches installation ID %d", request.InstallationID)
+	}
+}
+
+func ambiguousExecAppError(request execCredentialRequest) error {
+	switch {
+	case request.AppID != 0 && request.InstallationID != 0:
+		return fmt.Errorf("multiple GitHub App configurations match; use --repo to disambiguate the host")
+	case request.AppID != 0:
+		return fmt.Errorf("multiple GitHub App configurations match; use --installation-id or --repo")
+	default:
+		return fmt.Errorf("multiple GitHub App configurations match; use --app-id or --repo")
+	}
+}
+
+func inferExecHost(patterns []string) (string, error) {
+	host := ""
+	for _, pattern := range patterns {
+		candidate := strings.TrimSpace(pattern)
+		if candidate == "" {
+			continue
+		}
+
+		info, err := matcher.GetRepositoryInfo(candidate)
+		if err == nil {
+			candidate = info.Host
+		} else {
+			candidate = strings.TrimPrefix(candidate, "https://")
+			candidate = strings.TrimPrefix(candidate, "http://")
+			candidate = strings.TrimSuffix(candidate, "/")
+			if strings.Contains(candidate, "/") || strings.ContainsAny(candidate, "*") {
+				return "", fmt.Errorf("cannot infer host from GitHub App pattern %q; use --repo", pattern)
+			}
+		}
+
+		if host != "" && candidate != host {
+			return "", fmt.Errorf("selected GitHub App spans multiple hosts; use --repo")
+		}
+		host = candidate
+	}
+
+	if host == "" {
+		return "", fmt.Errorf("selected GitHub App has no host pattern; use --repo")
+	}
+	return host, nil
+}
+
+func execEnvironment(current []string, credential execCredential) []string {
 	blocked := map[string]struct{}{
 		"GH_TOKEN":                {},
 		"GITHUB_TOKEN":            {},
@@ -136,16 +367,15 @@ func execEnvironment(current []string, repo repository.Repository, token string)
 	}
 
 	tokenVariable := "GH_ENTERPRISE_TOKEN"
-	if repo.Host == "github.com" || strings.HasSuffix(repo.Host, ".ghe.com") {
+	if credential.Host == gitHubAPIHost || strings.HasSuffix(credential.Host, ".ghe.com") {
 		tokenVariable = "GH_TOKEN"
 	}
 
-	return append(
-		env,
-		tokenVariable+"="+token,
-		"GH_HOST="+repo.Host,
-		fmt.Sprintf("GH_REPO=%s/%s/%s", repo.Host, repo.Owner, repo.Name),
-	)
+	env = append(env, tokenVariable+"="+credential.Token, "GH_HOST="+credential.Host)
+	if credential.Repository != "" {
+		env = append(env, "GH_REPO="+credential.Repository)
+	}
+	return env
 }
 
 func runExecCommand(

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -7,61 +7,141 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cli/go-gh/v2/pkg/repository"
+	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
 )
 
 func TestExecCommand(t *testing.T) {
-	var (
-		resolvedRepo string
-		runName      string
-		runArgs      []string
-		runEnv       []string
-	)
+	t.Run("repository routing", func(t *testing.T) {
+		var (
+			resolvedRequest execCredentialRequest
+			runName         string
+			runArgs         []string
+			runEnv          []string
+		)
 
-	cmd := newExecCmd(
-		func(repo string) (string, error) {
-			resolvedRepo = repo
-			return "secret-token", nil
-		},
-		func(
-			_ context.Context,
-			name string,
-			args []string,
-			env []string,
-			_ io.Reader,
-			_ io.Writer,
-			_ io.Writer,
-		) error {
-			runName = name
-			runArgs = args
-			runEnv = env
-			return nil
-		},
-	)
-	cmd.SetArgs([]string{"--repo", "github.com/myorg/myrepo", "--", "gh", "api", "repos/{owner}/{repo}"})
+		cmd := newExecCmd(
+			func(request execCredentialRequest) (execCredential, error) {
+				resolvedRequest = request
+				return execCredential{
+					Token:      "secret-token",
+					Host:       gitHubAPIHost,
+					Repository: request.Repository,
+				}, nil
+			},
+			func(
+				_ context.Context,
+				name string,
+				args []string,
+				env []string,
+				_ io.Reader,
+				_ io.Writer,
+				_ io.Writer,
+			) error {
+				runName = name
+				runArgs = args
+				runEnv = env
+				return nil
+			},
+		)
+		cmd.SetArgs([]string{"--repo", "github.com/myorg/myrepo", "--", "gh", "api", "repos/{owner}/{repo}"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if resolvedRequest.Repository != "github.com/myorg/myrepo" {
+			t.Errorf("resolved repository = %q, want %q", resolvedRequest.Repository, "github.com/myorg/myrepo")
+		}
+		if runName != "gh" {
+			t.Errorf("command name = %q, want %q", runName, "gh")
+		}
+		if got := strings.Join(runArgs, " "); got != "api repos/{owner}/{repo}" {
+			t.Errorf("command args = %q, want %q", got, "api repos/{owner}/{repo}")
+		}
+		assertEnvironmentValue(t, runEnv, "GH_TOKEN", "secret-token")
+		assertEnvironmentValue(t, runEnv, "GH_HOST", gitHubAPIHost)
+		assertEnvironmentValue(t, runEnv, "GH_REPO", "github.com/myorg/myrepo")
+	})
+
+	t.Run("repository-independent App routing", func(t *testing.T) {
+		var resolvedRequest execCredentialRequest
+		var runEnv []string
+
+		cmd := newExecCmd(
+			func(request execCredentialRequest) (execCredential, error) {
+				resolvedRequest = request
+				return execCredential{Token: "app-token", Host: gitHubAPIHost}, nil
+			},
+			func(
+				_ context.Context,
+				_ string,
+				_ []string,
+				env []string,
+				_ io.Reader,
+				_ io.Writer,
+				_ io.Writer,
+			) error {
+				runEnv = env
+				return nil
+			},
+		)
+		cmd.SetArgs([]string{
+			"--app-id", "123456",
+			"--installation-id", "789012",
+			"--", "gh", "api", "/installation/repositories",
+		})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if resolvedRequest.Repository != "" {
+			t.Errorf("resolved repository = %q, want empty", resolvedRequest.Repository)
+		}
+		if resolvedRequest.AppID != 123456 || resolvedRequest.InstallationID != 789012 {
+			t.Errorf("resolved IDs = (%d, %d), want (123456, 789012)", resolvedRequest.AppID, resolvedRequest.InstallationID)
+		}
+		assertEnvironmentValue(t, runEnv, "GH_TOKEN", "app-token")
+		assertEnvironmentValue(t, runEnv, "GH_HOST", gitHubAPIHost)
+		assertEnvironmentMissing(t, runEnv, "GH_REPO")
+	})
+}
+
+func TestExecCommandRejectsNonPositiveSelectors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "zero App ID", args: []string{"--app-id", "0", "--", "gh", "api", "user"}},
+		{name: "negative App ID", args: []string{"--app-id", "-1", "--", "gh", "api", "user"}},
+		{name: "zero installation ID", args: []string{"--installation-id", "0", "--", "gh", "api", "user"}},
+		{name: "negative installation ID", args: []string{"--installation-id", "-1", "--", "gh", "api", "user"}},
 	}
-	if resolvedRepo != "github.com/myorg/myrepo" {
-		t.Errorf("resolved repository = %q, want %q", resolvedRepo, "github.com/myorg/myrepo")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newExecCmd(
+				func(execCredentialRequest) (execCredential, error) {
+					t.Fatal("resolver should not be called")
+					return execCredential{}, nil
+				},
+				func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
+					t.Fatal("runner should not be called")
+					return nil
+				},
+			)
+			cmd.SetArgs(tt.args)
+
+			if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "must be positive") {
+				t.Fatalf("Execute() error = %v, want positive-value error", err)
+			}
+		})
 	}
-	if runName != "gh" {
-		t.Errorf("command name = %q, want %q", runName, "gh")
-	}
-	if got := strings.Join(runArgs, " "); got != "api repos/{owner}/{repo}" {
-		t.Errorf("command args = %q, want %q", got, "api repos/{owner}/{repo}")
-	}
-	assertEnvironmentValue(t, runEnv, "GH_TOKEN", "secret-token")
-	assertEnvironmentValue(t, runEnv, "GH_HOST", "github.com")
-	assertEnvironmentValue(t, runEnv, "GH_REPO", "github.com/myorg/myrepo")
 }
 
 func TestExecCommandPropagatesErrors(t *testing.T) {
-	t.Run("token resolution", func(t *testing.T) {
+	t.Run("credential resolution", func(t *testing.T) {
 		wantErr := errors.New("token unavailable")
 		cmd := newExecCmd(
-			func(string) (string, error) { return "", wantErr },
+			func(execCredentialRequest) (execCredential, error) { return execCredential{}, wantErr },
 			func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
 				t.Fatal("runner should not be called")
 				return nil
@@ -77,7 +157,9 @@ func TestExecCommandPropagatesErrors(t *testing.T) {
 	t.Run("child process", func(t *testing.T) {
 		wantErr := errors.New("child failed")
 		cmd := newExecCmd(
-			func(string) (string, error) { return "secret-token", nil },
+			func(request execCredentialRequest) (execCredential, error) {
+				return execCredential{Token: "secret-token", Host: gitHubAPIHost, Repository: request.Repository}, nil
+			},
 			func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
 				return wantErr
 			},
@@ -93,8 +175,109 @@ func TestExecCommandPropagatesErrors(t *testing.T) {
 	})
 }
 
+func TestSelectExecApp(t *testing.T) {
+	cfg := &config.Config{GitHubApps: []config.GitHubApp{
+		{Name: "org-a", AppID: 100, InstallationID: 200, Patterns: []string{"github.com/org-a/*"}},
+		{Name: "org-b", AppID: 100, InstallationID: 300, Patterns: []string{"github.com/org-b/*"}},
+		{Name: "enterprise", AppID: 400, InstallationID: 500, Patterns: []string{"github.example.com/org/*"}},
+	}}
+
+	tests := []struct {
+		name        string
+		request     execCredentialRequest
+		wantName    string
+		wantErrText string
+	}{
+		{
+			name:     "installation ID",
+			request:  execCredentialRequest{InstallationID: 300},
+			wantName: "org-b",
+		},
+		{
+			name:     "App and installation ID",
+			request:  execCredentialRequest{AppID: 100, InstallationID: 200},
+			wantName: "org-a",
+		},
+		{
+			name:     "repository disambiguates App ID",
+			request:  execCredentialRequest{Repository: "github.com/org-b/repo", AppID: 100},
+			wantName: "org-b",
+		},
+		{
+			name:        "ambiguous App ID",
+			request:     execCredentialRequest{AppID: 100},
+			wantErrText: "multiple GitHub App configurations match",
+		},
+		{
+			name:        "unknown installation",
+			request:     execCredentialRequest{InstallationID: 999},
+			wantErrText: "no configured GitHub App matches",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app, err := selectExecApp(cfg, tt.request)
+			if tt.wantErrText != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("selectExecApp() error = %v, want containing %q", err, tt.wantErrText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("selectExecApp() error = %v", err)
+			}
+			if app.Name != tt.wantName {
+				t.Errorf("selected app = %q, want %q", app.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestInferExecHost(t *testing.T) {
+	tests := []struct {
+		name        string
+		patterns    []string
+		want        string
+		wantErrText string
+	}{
+		{
+			name:     "same host",
+			patterns: []string{"github.com/org-a/*", "https://github.com/org-b/*"},
+			want:     gitHubAPIHost,
+		},
+		{
+			name:        "multiple hosts",
+			patterns:    []string{"github.com/org/*", "github.example.com/org/*"},
+			wantErrText: "spans multiple hosts",
+		},
+		{
+			name:        "no patterns",
+			wantErrText: "has no host pattern",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := inferExecHost(tt.patterns)
+			if tt.wantErrText != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("inferExecHost() error = %v, want containing %q", err, tt.wantErrText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("inferExecHost() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("inferExecHost() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExecEnvironment(t *testing.T) {
-	t.Run("github.com", func(t *testing.T) {
+	t.Run("github.com repository", func(t *testing.T) {
 		env := execEnvironment(
 			[]string{
 				"PATH=/usr/bin",
@@ -105,36 +288,38 @@ func TestExecEnvironment(t *testing.T) {
 				"GH_HOST=old.example.com",
 				"GH_REPO=old/repo",
 			},
-			repository.Repository{Host: "github.com", Owner: "myorg", Name: "myrepo"},
-			"new-token",
+			execCredential{
+				Token:      "new-token",
+				Host:       gitHubAPIHost,
+				Repository: "github.com/myorg/myrepo",
+			},
 		)
 
 		assertEnvironmentValue(t, env, "PATH", "/usr/bin")
 		assertEnvironmentValue(t, env, "GH_TOKEN", "new-token")
-		assertEnvironmentValue(t, env, "GH_HOST", "github.com")
+		assertEnvironmentValue(t, env, "GH_HOST", gitHubAPIHost)
 		assertEnvironmentValue(t, env, "GH_REPO", "github.com/myorg/myrepo")
 		assertEnvironmentMissing(t, env, "GITHUB_TOKEN")
 		assertEnvironmentMissing(t, env, "GH_ENTERPRISE_TOKEN")
 		assertEnvironmentMissing(t, env, "GITHUB_ENTERPRISE_TOKEN")
 	})
 
-	t.Run("GitHub Enterprise Server", func(t *testing.T) {
+	t.Run("GitHub Enterprise Server without repository", func(t *testing.T) {
 		env := execEnvironment(
 			nil,
-			repository.Repository{Host: "github.example.com", Owner: "myorg", Name: "myrepo"},
-			"enterprise-token",
+			execCredential{Token: "enterprise-token", Host: "github.example.com"},
 		)
 
 		assertEnvironmentValue(t, env, "GH_ENTERPRISE_TOKEN", "enterprise-token")
 		assertEnvironmentValue(t, env, "GH_HOST", "github.example.com")
 		assertEnvironmentMissing(t, env, "GH_TOKEN")
+		assertEnvironmentMissing(t, env, "GH_REPO")
 	})
 
 	t.Run("GitHub Enterprise Cloud data residency", func(t *testing.T) {
 		env := execEnvironment(
 			nil,
-			repository.Repository{Host: "octocorp.ghe.com", Owner: "myorg", Name: "myrepo"},
-			"cloud-token",
+			execCredential{Token: "cloud-token", Host: "octocorp.ghe.com"},
 		)
 
 		assertEnvironmentValue(t, env, "GH_TOKEN", "cloud-token")

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -87,6 +87,9 @@ func TestExecCommandPropagatesErrors(t *testing.T) {
 		if err := cmd.Execute(); !errors.Is(err, wantErr) {
 			t.Fatalf("Execute() error = %v, want %v", err, wantErr)
 		}
+		if !cmd.SilenceErrors || !cmd.SilenceUsage {
+			t.Fatal("child failures should not print an error or command usage")
+		}
 	})
 }
 

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/cli/go-gh/v2/pkg/repository"
+)
+
+func TestExecCommand(t *testing.T) {
+	var (
+		resolvedRepo string
+		runName      string
+		runArgs      []string
+		runEnv       []string
+	)
+
+	cmd := newExecCmd(
+		func(repo string) (string, error) {
+			resolvedRepo = repo
+			return "secret-token", nil
+		},
+		func(
+			_ context.Context,
+			name string,
+			args []string,
+			env []string,
+			_ io.Reader,
+			_ io.Writer,
+			_ io.Writer,
+		) error {
+			runName = name
+			runArgs = args
+			runEnv = env
+			return nil
+		},
+	)
+	cmd.SetArgs([]string{"--repo", "github.com/myorg/myrepo", "--", "gh", "api", "repos/{owner}/{repo}"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if resolvedRepo != "github.com/myorg/myrepo" {
+		t.Errorf("resolved repository = %q, want %q", resolvedRepo, "github.com/myorg/myrepo")
+	}
+	if runName != "gh" {
+		t.Errorf("command name = %q, want %q", runName, "gh")
+	}
+	if got := strings.Join(runArgs, " "); got != "api repos/{owner}/{repo}" {
+		t.Errorf("command args = %q, want %q", got, "api repos/{owner}/{repo}")
+	}
+	assertEnvironmentValue(t, runEnv, "GH_TOKEN", "secret-token")
+	assertEnvironmentValue(t, runEnv, "GH_HOST", "github.com")
+	assertEnvironmentValue(t, runEnv, "GH_REPO", "github.com/myorg/myrepo")
+}
+
+func TestExecCommandPropagatesErrors(t *testing.T) {
+	t.Run("token resolution", func(t *testing.T) {
+		wantErr := errors.New("token unavailable")
+		cmd := newExecCmd(
+			func(string) (string, error) { return "", wantErr },
+			func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
+				t.Fatal("runner should not be called")
+				return nil
+			},
+		)
+		cmd.SetArgs([]string{"--repo", "github.com/myorg/myrepo", "--", "gh", "api", "user"})
+
+		if err := cmd.Execute(); !errors.Is(err, wantErr) {
+			t.Fatalf("Execute() error = %v, want %v", err, wantErr)
+		}
+	})
+
+	t.Run("child process", func(t *testing.T) {
+		wantErr := errors.New("child failed")
+		cmd := newExecCmd(
+			func(string) (string, error) { return "secret-token", nil },
+			func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
+				return wantErr
+			},
+		)
+		cmd.SetArgs([]string{"--repo", "github.com/myorg/myrepo", "--", "gh", "api", "user"})
+
+		if err := cmd.Execute(); !errors.Is(err, wantErr) {
+			t.Fatalf("Execute() error = %v, want %v", err, wantErr)
+		}
+	})
+}
+
+func TestExecEnvironment(t *testing.T) {
+	t.Run("github.com", func(t *testing.T) {
+		env := execEnvironment(
+			[]string{
+				"PATH=/usr/bin",
+				"GH_TOKEN=old-gh-token",
+				"GITHUB_TOKEN=old-github-token",
+				"GH_ENTERPRISE_TOKEN=old-enterprise-token",
+				"GITHUB_ENTERPRISE_TOKEN=old-github-enterprise-token",
+				"GH_HOST=old.example.com",
+				"GH_REPO=old/repo",
+			},
+			repository.Repository{Host: "github.com", Owner: "myorg", Name: "myrepo"},
+			"new-token",
+		)
+
+		assertEnvironmentValue(t, env, "PATH", "/usr/bin")
+		assertEnvironmentValue(t, env, "GH_TOKEN", "new-token")
+		assertEnvironmentValue(t, env, "GH_HOST", "github.com")
+		assertEnvironmentValue(t, env, "GH_REPO", "github.com/myorg/myrepo")
+		assertEnvironmentMissing(t, env, "GITHUB_TOKEN")
+		assertEnvironmentMissing(t, env, "GH_ENTERPRISE_TOKEN")
+		assertEnvironmentMissing(t, env, "GITHUB_ENTERPRISE_TOKEN")
+	})
+
+	t.Run("GitHub Enterprise Server", func(t *testing.T) {
+		env := execEnvironment(
+			nil,
+			repository.Repository{Host: "github.example.com", Owner: "myorg", Name: "myrepo"},
+			"enterprise-token",
+		)
+
+		assertEnvironmentValue(t, env, "GH_ENTERPRISE_TOKEN", "enterprise-token")
+		assertEnvironmentValue(t, env, "GH_HOST", "github.example.com")
+		assertEnvironmentMissing(t, env, "GH_TOKEN")
+	})
+
+	t.Run("GitHub Enterprise Cloud data residency", func(t *testing.T) {
+		env := execEnvironment(
+			nil,
+			repository.Repository{Host: "octocorp.ghe.com", Owner: "myorg", Name: "myrepo"},
+			"cloud-token",
+		)
+
+		assertEnvironmentValue(t, env, "GH_TOKEN", "cloud-token")
+		assertEnvironmentMissing(t, env, "GH_ENTERPRISE_TOKEN")
+	})
+}
+
+func assertEnvironmentValue(t *testing.T, env []string, key, want string) {
+	t.Helper()
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			if got := strings.TrimPrefix(entry, prefix); got != want {
+				t.Errorf("%s = %q, want %q", key, got, want)
+			}
+			return
+		}
+	}
+	t.Errorf("%s is missing from environment", key)
+}
+
+func assertEnvironmentMissing(t *testing.T, env []string, key string) {
+	t.Helper()
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			t.Errorf("%s unexpectedly present in environment", key)
+			return
+		}
+	}
+}

--- a/cmd/gitconfig.go
+++ b/cmd/gitconfig.go
@@ -191,8 +191,8 @@ func syncGitConfig(scope string, auto bool) error {
 	}
 
 	if auto {
-		configurePattern("github.com", "Automatic mode")
-		setUseHttpPath(scope, "github.com")
+		configurePattern(gitHubAPIHost, "Automatic mode")
+		setUseHttpPath(scope, gitHubAPIHost)
 		return nil
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,7 @@ func init() {
 	rootCmd.AddCommand(NewListCmd())
 	rootCmd.AddCommand(NewRemoveCmd())
 	rootCmd.AddCommand(NewTestCmd())
+	rootCmd.AddCommand(NewExecCmd())
 	rootCmd.AddCommand(NewGitCredentialCmd())
 	rootCmd.AddCommand(NewGitConfigCmd())
 	rootCmd.AddCommand(NewMigrateCmd())

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -109,13 +110,21 @@ func getCurrentRepository() (string, error) {
 }
 
 func currentGitRemoteURL() (string, error) {
-	if output, err := exec.Command("git", "config", "--get", "remote.origin.url").Output(); err == nil {
+	if output, err := exec.Command("git", "config", "--local", "--get", "remote.origin.url").Output(); err == nil {
 		return strings.TrimSpace(string(output)), nil
 	}
 
-	output, err := exec.Command("git", "config", "--get-regexp", `^remote\..*\.url$`).Output()
+	output, err := exec.Command("git", "config", "--local", "--get-regexp", `^remote\..*\.url$`).CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("no git remotes configured for this repository")
+		message := strings.TrimSpace(string(output))
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && message == "" {
+			return "", fmt.Errorf("no git remotes configured for this repository")
+		}
+		if message != "" {
+			return "", fmt.Errorf("failed to read git remotes: %w: %s", err, message)
+		}
+		return "", fmt.Errorf("failed to read git remotes: %w", err)
 	}
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
 		fields := strings.Fields(line)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -96,9 +97,40 @@ func testRun(repo *string, verbose *bool) func(*cobra.Command, []string) error {
 }
 
 func getCurrentRepository() (string, error) {
-	repo, err := repository.Current()
+	if override := os.Getenv("GH_REPO"); override != "" {
+		return canonicalRepository(override)
+	}
+
+	remoteURL, err := currentGitRemoteURL()
 	if err != nil {
 		return "", fmt.Errorf("failed to determine current repository: %w", err)
+	}
+	return canonicalRepository(remoteURL)
+}
+
+func currentGitRemoteURL() (string, error) {
+	if output, err := exec.Command("git", "config", "--get", "remote.origin.url").Output(); err == nil {
+		return strings.TrimSpace(string(output)), nil
+	}
+
+	output, err := exec.Command("git", "config", "--get-regexp", `^remote\..*\.url$`).Output()
+	if err != nil {
+		return "", fmt.Errorf("no git remotes configured for this repository")
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 {
+			return fields[len(fields)-1], nil
+		}
+	}
+
+	return "", fmt.Errorf("no git remotes configured for this repository")
+}
+
+func canonicalRepository(value string) (string, error) {
+	repo, err := repository.Parse(value)
+	if err != nil {
+		return "", err
 	}
 
 	return fmt.Sprintf("%s/%s/%s", repo.Host, repo.Owner, repo.Name), nil

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/auth"
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/secrets"
+	"github.com/cli/go-gh/v2/pkg/repository"
 	"github.com/spf13/cobra"
 )
 
@@ -95,8 +96,12 @@ func testRun(repo *string, verbose *bool) func(*cobra.Command, []string) error {
 }
 
 func getCurrentRepository() (string, error) {
-	// This is a placeholder - in reality we'd use go-gh's repository detection
-	return "", fmt.Errorf("current repository detection not implemented yet")
+	repo, err := repository.Current()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine current repository: %w", err)
+	}
+
+	return fmt.Sprintf("%s/%s/%s", repo.Host, repo.Owner, repo.Name), nil
 }
 
 func testAPIAccess(token, repoURL string, verbose bool) error {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -155,7 +155,7 @@ func testAPIAccess(token, repoURL string, verbose bool) error {
 
 	// Use raw HTTP instead of go-gh to avoid GitHub CLI auth requirement
 	apiURL := fmt.Sprintf("https://%s/api/v3/repos/%s/%s", host, owner, repo)
-	if host == "github.com" {
+	if host == gitHubAPIHost {
 		apiURL = fmt.Sprintf("https://api.github.com/repos/%s/%s", owner, repo)
 	}
 
@@ -227,7 +227,7 @@ func extractHost(repoURL string) string {
 	}
 
 	// Default to github.com
-	return "github.com"
+	return gitHubAPIHost
 }
 
 func extractOwnerRepo(repoURL string) (owner, repo string, err error) {

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -165,12 +166,18 @@ func TestExtractOwnerRepo(t *testing.T) {
 }
 
 func TestGetCurrentRepository(t *testing.T) {
-	t.Run("not implemented", func(t *testing.T) {
-		_, err := getCurrentRepository()
-		if err == nil {
-			t.Error("Expected error for not implemented function")
-		}
-	})
+	tempDir := t.TempDir()
+	runGit(t, tempDir, "init")
+	runGit(t, tempDir, "remote", "add", "origin", "git@github.com:myorg/myrepo.git")
+	withWorkingDirectory(t, tempDir)
+
+	got, err := getCurrentRepository()
+	if err != nil {
+		t.Fatalf("getCurrentRepository() error = %v", err)
+	}
+	if got != "github.com/myorg/myrepo" {
+		t.Errorf("getCurrentRepository() = %q, want %q", got, "github.com/myorg/myrepo")
+	}
 }
 
 func TestDetermineRepositoryURL(t *testing.T) {
@@ -183,11 +190,6 @@ func TestDetermineRepositoryURL(t *testing.T) {
 			name:    "with repo specified",
 			repo:    "https://github.com/myorg/myrepo",
 			wantErr: false,
-		},
-		{
-			name:    "without repo - should fail",
-			repo:    "",
-			wantErr: true,
 		},
 	}
 
@@ -212,6 +214,39 @@ func TestDetermineRepositoryURL(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("without repo outside git repository", func(t *testing.T) {
+		withWorkingDirectory(t, t.TempDir())
+		_, err := determineRepositoryURL("")
+		if err == nil {
+			t.Fatal("determineRepositoryURL() error = nil, want an error")
+		}
+	})
+}
+
+func runGit(t *testing.T, directory string, args ...string) {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = directory
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
+func withWorkingDirectory(t *testing.T, directory string) {
+	t.Helper()
+	original, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd() error = %v", err)
+	}
+	if err := os.Chdir(directory); err != nil {
+		t.Fatalf("os.Chdir(%q) error = %v", directory, err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(original); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	})
 }
 
 func TestDisplayTestResults(t *testing.T) {

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -170,6 +170,7 @@ func TestGetCurrentRepository(t *testing.T) {
 	runGit(t, tempDir, "init")
 	runGit(t, tempDir, "remote", "add", "origin", "git@github.com:myorg/myrepo.git")
 	withWorkingDirectory(t, tempDir)
+	t.Setenv("HOME", t.TempDir())
 
 	got, err := getCurrentRepository()
 	if err != nil {
@@ -177,6 +178,18 @@ func TestGetCurrentRepository(t *testing.T) {
 	}
 	if got != "github.com/myorg/myrepo" {
 		t.Errorf("getCurrentRepository() = %q, want %q", got, "github.com/myorg/myrepo")
+	}
+}
+
+func TestGetCurrentRepositoryFromEnvironment(t *testing.T) {
+	t.Setenv("GH_REPO", "github.example.com/myorg/myrepo")
+
+	got, err := getCurrentRepository()
+	if err != nil {
+		t.Fatalf("getCurrentRepository() error = %v", err)
+	}
+	if got != "github.example.com/myorg/myrepo" {
+		t.Errorf("getCurrentRepository() = %q, want %q", got, "github.example.com/myorg/myrepo")
 	}
 }
 

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -193,6 +193,18 @@ func TestGetCurrentRepositoryFromEnvironment(t *testing.T) {
 	}
 }
 
+func TestCurrentGitRemoteURLPreservesGitError(t *testing.T) {
+	withWorkingDirectory(t, t.TempDir())
+
+	_, err := currentGitRemoteURL()
+	if err == nil {
+		t.Fatal("currentGitRemoteURL() error = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "failed to read git remotes") || !strings.Contains(err.Error(), "fatal:") {
+		t.Errorf("currentGitRemoteURL() error = %q, want git diagnostic", err)
+	}
+}
+
 func TestDetermineRepositoryURL(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/AmadeusITGroup/gh-app-auth/cmd"
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/logger"
@@ -14,7 +15,7 @@ func main() {
 	logger.Initialize()
 
 	if err := cmd.Execute(); err != nil {
-		var exitErr interface{ ExitCode() int }
+		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			logger.Close()
 			os.Exit(exitErr.ExitCode())

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -13,6 +14,11 @@ func main() {
 	logger.Initialize()
 
 	if err := cmd.Execute(); err != nil {
+		var exitErr interface{ ExitCode() int }
+		if errors.As(err, &exitErr) {
+			logger.Close()
+			os.Exit(exitErr.ExitCode())
+		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		logger.Close()
 		os.Exit(1)


### PR DESCRIPTION
## Description

Adds `gh app-auth exec`, which mints the configured repository credential on demand and runs a child command with GitHub CLI authentication. This addresses the agent and automation use case in #50 without printing or persisting installation tokens.

Fixes #50

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📚 Documentation update
- [x] 🧪 Test updates
- [x] 🔒 Security improvements

## Changes Made

- Add `exec [--repo <repository>] -- <command> [args...]` for GitHub App and PAT-backed commands.
- Set `GH_TOKEN` or `GH_ENTERPRISE_TOKEN`, plus `GH_HOST` and `GH_REPO`, only in the child environment; remove conflicting inherited GitHub token variables.
- Detect the current repository directly from Git remotes, so the command works before any human `gh auth login`.
- Preserve child exit codes without printing command usage for child failures.
- Document GitHub CLI usage and add focused command, environment, error, and repository-discovery tests.

## Testing

- [x] Unit tests pass: `go test ./...`
- [x] Build succeeds: `go build -o gh-app-auth .`
- [x] Manual testing performed
- [x] Integration tests with real GitHub Apps (if applicable)

### Test Configuration

- **OS**: macOS arm64
- **Go version**: 1.26.2
- **GitHub CLI version**: 2.97.0

Real-App smoke test used an isolated temporary HOME with no human GitHub CLI session. From an existing checkout, `gh-app-auth exec -- gh api repos/{owner}/{repo}` resolved and accessed the App's selected repository. A child process exiting with status 7 returned status 7. Temporary credentials and binaries were removed after the test.

## Security Considerations

- [x] No sensitive data (tokens, keys) exposed in code or tests
- [x] Input validation added/reviewed for new functionality
- [x] Private key handling follows security best practices
- [x] Token caching security maintained
- [x] No new attack vectors introduced

The command is intentionally selected by the user and is executed directly with `exec.CommandContext`, never through a shell. Existing GitHub token variables are removed before the short-lived credential is added to the child environment.

## Documentation

- [x] Code comments updated
- [x] README.md updated (if needed)
- [x] Architecture documentation updated (not needed; existing auth boundaries are unchanged)
- [x] Command help text updated (if needed)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] **Commit messages follow [Conventional Commits](https://github.com/AmadeusITGroup/gh-app-auth/blob/main/CONTRIBUTING.md#commit-message-guidelines) format**
- [x] **PR title follows conventional commits format**

## Review aids

Sanitized behavior contract:

```text
configured App/PAT + repository + child command
  -> mint short-lived token
  -> replace inherited GitHub auth variables in child environment
  -> set GH_HOST and GH_REPO
  -> exec child directly
  -> return the child's exit code
```

## Breaking Changes

None.
