### PR TITLE
feat(cli): support GitHub App Client ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           go-version: '1.21'
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@v2.25.0
+        uses: securego/gosec@v2.28.0
         with:
           args: '-no-fail -fmt sarif -out gosec-results.sarif ./...'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Lint markdown files
-        uses: DavidAnson/markdownlint-cli2-action@v23
+        uses: DavidAnson/markdownlint-cli2-action@v24.1.0
         with:
           globs: |
             **/*.md

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,7 +59,7 @@ jobs:
           cache: true
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@v2.25.0
+        uses: securego/gosec@v2.28.0
         with:
           args: '-no-fail -fmt sarif -out gosec.sarif ./...'
 

--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ mermaid-filter.err
 # OS generated files
 .DS_Store
 Thumbs.db
+
+# Test artifacts
+pkg/logger/1

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ BUILD_TIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -ldflags "-X main.Version=$(VERSION) -X main.Commit=$(COMMIT) -X main.BuildTime=$(BUILD_TIME)"
 
 # Go tool commands
-GOLANGCI_LINT := go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+GOLANGCI_LINT := go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
 GOIMPORTS := go run golang.org/x/tools/cmd/goimports@latest
 STATICCHECK := go run honnef.co/go/tools/cmd/staticcheck@latest
 GOCYCLO := go run github.com/fzipp/gocyclo/cmd/gocyclo@latest

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ MISSPELL := go run github.com/client9/misspell/cmd/misspell@latest
 GOSEC := go run github.com/securego/gosec/v2/cmd/gosec@latest
 GOVULNCHECK := go run golang.org/x/vuln/cmd/govulncheck@latest
 ACTIONLINT := go run github.com/rhysd/actionlint/cmd/actionlint@latest
+NFPM_CMD := go run github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
 
 # Build the extension
 build:

--- a/README.md
+++ b/README.md
@@ -114,14 +114,14 @@ See [URL Prefix Routing Guide](docs/PATTERN_ROUTING.md) for detailed examples.
 
 - `gh app-auth setup` - Configure GitHub Apps or Personal Access Tokens (`--pat`)
 - `gh app-auth list` - List configured credentials (`--verify-keys` to check accessibility)
-- `gh app-auth remove` - Remove GitHub App (`--app-id`) or PAT (`--pat-name`) configuration
+- `gh app-auth remove` - Remove GitHub App (`--app-id` or `--client-id`) or PAT (`--pat-name`) configuration
 - `gh app-auth test` - Test authentication for a repository
 - `gh app-auth scope` - Fetch and display GitHub App installation scope (which repos the app can access)
 - `gh app-auth config` - Show configuration file location (`--path`) or content (`--show`)
 - `gh app-auth gitconfig` - Manage git credential helper configuration
   - `--sync` - Configure git for all apps/PATs
   - `--clean` - Remove all gh-app-auth git configurations
-  - `--auto` - Auto-mode using `GH_APP_ID` and `GH_APP_PRIVATE_KEY_PATH` env vars
+  - `--auto` - Auto-mode using `GH_APP_ID` (or `GH_APP_CLIENT_ID`) and `GH_APP_PRIVATE_KEY_PATH` env vars
 - `gh app-auth migrate` - Migrate private keys to encrypted storage
 - `gh app-auth git-credential` - Git credential helper (internal)
 
@@ -148,10 +148,13 @@ This extension now supports **encrypted storage** for private keys using OS-nati
 ```bash
 # From environment variable (recommended for CI/CD)
 export GH_APP_PRIVATE_KEY="$(cat ~/my-key.pem)"
-gh app-auth setup --app-id 12345 --patterns "github.com/org/*"
+gh app-auth setup --client-id Iv1.your_client_id --patterns "github.com/org/*"
 
-# From file (stores in keyring, keeps file as fallback)
+# From file using legacy numeric App ID
 gh app-auth setup --app-id 12345 --key-file ~/my-key.pem --patterns "github.com/org/*"
+
+# From file using Client ID (preferred)
+gh app-auth setup --client-id Iv1.your_client_id --key-file ~/my-key.pem --patterns "github.com/org/*"
 
 # Store a Personal Access Token in the keyring
 gh app-auth setup --pat ghp_your_token --patterns "github.com/org/"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A GitHub CLI extension that enables GitHub App authentication for Git operations
 - **Encrypted Storage**: Private keys stored in OS-native keyring (Keychain, Credential Manager, Secret Service)
 - **Pattern Routing**: Configure different apps for different repository URL prefixes
 - **Git Integration**: Git credential helper protocol support
+- **GitHub CLI Integration**: Run `gh` and other commands with short-lived credentials
 - **Token Caching**: In-memory caching of installation tokens (55-min TTL)
 - **Multi-Host**: GitHub.com, GitHub Enterprise, and Bitbucket Server support
 - **CI/CD Ready**: Environment variable support (`GH_APP_PRIVATE_KEY`)
@@ -92,7 +93,28 @@ gh app-auth test --repo github.com/myorg/private-repo
 
 # Use git normally - now uses GitHub App authentication
 git clone https://github.com/myorg/private-repo.git
+
+# Run gh with a short-lived token for the current repository
+gh app-auth exec -- gh pr list
+
+# Run gh outside a repository by specifying the authentication target
+gh app-auth exec --repo github.com/myorg/private-repo -- \
+  gh api repos/{owner}/{repo}
+
+# Run an API command that is not scoped to one repository
+gh app-auth exec \
+  --app-id 123456 \
+  --installation-id 789012 \
+  -- gh api /installation/repositories
 ```
+
+`exec` mints a token on demand and exposes it only to the child process through
+`GH_TOKEN` (or `GH_ENTERPRISE_TOKEN` for GitHub Enterprise Server). Repository
+routing sets both `GH_HOST` and `GH_REPO`; selecting a configured App with
+`--app-id` or `--installation-id` sets `GH_HOST` without inventing a repository
+scope. Use both IDs to disambiguate Apps configured for multiple installations.
+PAT selection remains repository-based. No token is printed or persisted by
+this command.
 
 ## URL Prefix Routing
 
@@ -116,6 +138,7 @@ See [URL Prefix Routing Guide](docs/PATTERN_ROUTING.md) for detailed examples.
 - `gh app-auth list` - List configured credentials (`--verify-keys` to check accessibility)
 - `gh app-auth remove` - Remove GitHub App (`--app-id` or `--client-id`) or PAT (`--pat-name`) configuration
 - `gh app-auth test` - Test authentication for a repository
+- `gh app-auth exec` - Run a command with short-lived credentials selected by repository, App ID, or installation ID
 - `gh app-auth scope` - Fetch and display GitHub App installation scope (which repos the app can access)
 - `gh app-auth config` - Show configuration file location (`--path`) or content (`--show`)
 - `gh app-auth gitconfig` - Manage git credential helper configuration

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -31,48 +31,44 @@ func NewDebugCmd() *cobra.Command {
 }
 
 func newListInstallationsCmd() *cobra.Command {
-	var appID int64
+	var (
+		appID    int64
+		clientID string
+	)
 
 	cmd := &cobra.Command{
-		Use:     "list-installations",
-		Short:   "List all installations for a GitHub App",
-		Long:    "Lists all installations for a GitHub App using the configured private key.",
-		Example: "  gh app-auth debug list-installations --app-id 2083241",
+		Use:   "list-installations",
+		Short: "List all installations for a GitHub App",
+		Long:  "Lists all installations for a GitHub App using the configured private key.",
+		Example: `  gh app-auth debug list-installations --app-id 2083241
+  gh app-auth debug list-installations --client-id Iv1.your_client_id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
 				return fmt.Errorf("failed to load configuration: %w", err)
 			}
 
-			apps := make([]*config.GitHubApp, 0, len(cfg.GitHubApps))
-			if cmd.Flags().Changed("app-id") {
-				for i := range cfg.GitHubApps {
-					if cfg.GitHubApps[i].AppID == appID {
-						apps = append(apps, &cfg.GitHubApps[i])
-						break
-					}
-				}
-				if len(apps) == 0 {
-					return fmt.Errorf("app with ID %d not found in configuration", appID)
-				}
-			} else {
-				for i := range cfg.GitHubApps {
-					apps = append(apps, &cfg.GitHubApps[i])
-				}
-				if len(apps) == 0 {
-					fmt.Println("No GitHub Apps configured. Run 'gh app-auth setup' to add one.")
-					return nil
-				}
+			appIDSet := cmd.Flags().Changed("app-id")
+			clientIDSet := cmd.Flags().Changed("client-id")
+			apps, err := selectDebugApps(cfg, appID, clientID, appIDSet, clientIDSet)
+			if err != nil {
+				return err
+			}
+			if len(apps) == 0 {
+				fmt.Println("No GitHub Apps configured. Run 'gh app-auth setup' to add one.")
+				return nil
 			}
 
+			filtered := appIDSet || clientIDSet
+
 			for idx, app := range apps {
-				fmt.Printf("=== %s (App ID %d) ===\n", appDisplayName(app), app.AppID)
+				fmt.Printf("=== %s (App ID: %s) ===\n", appDisplayName(app), app.GetIdentifier())
 
 				authenticator := auth.NewAuthenticator()
 				jwtToken, err := authenticator.GenerateJWTForApp(app)
 				if err != nil {
-					if cmd.Flags().Changed("app-id") {
-						return fmt.Errorf("failed to generate JWT for app %d: %w", app.AppID, err)
+					if filtered {
+						return fmt.Errorf("failed to generate JWT for app %s: %w", app.GetIdentifier(), err)
 					}
 					fmt.Printf("  Error: %v\n\n", err)
 					continue
@@ -82,8 +78,8 @@ func newListInstallationsCmd() *cobra.Command {
 
 				installations, err := listInstallations(jwtToken)
 				if err != nil {
-					if cmd.Flags().Changed("app-id") {
-						return fmt.Errorf("failed to list installations for app %d: %w", app.AppID, err)
+					if filtered {
+						return fmt.Errorf("failed to list installations for app %s: %w", app.GetIdentifier(), err)
 					}
 					fmt.Printf("  Error listing installations: %v\n\n", err)
 					continue
@@ -112,52 +108,49 @@ func newListInstallationsCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Int64Var(&appID, "app-id", 0, "GitHub App ID (optional)")
+	cmd.Flags().Int64Var(&appID, "app-id", 0, "GitHub App ID (optional, mutually exclusive with --client-id)")
+	cmd.Flags().StringVar(&clientID, "client-id", "", "GitHub App Client ID (optional, mutually exclusive with --app-id)")
 
 	return cmd
 }
 
 func newListInstallationReposCmd() *cobra.Command {
-	var appID int64
+	var (
+		appID    int64
+		clientID string
+	)
 
 	cmd := &cobra.Command{
-		Use:     "list-repositories",
-		Short:   "List repositories accessible to an installation",
-		Long:    "Lists repositories accessible to an installation using the configured GitHub App.",
-		Example: "  gh app-auth debug list-repositories --app-id 2083241",
+		Use:   "list-repositories",
+		Short: "List repositories accessible to an installation",
+		Long:  "Lists repositories accessible to an installation using the configured GitHub App.",
+		Example: `  gh app-auth debug list-repositories --app-id 2083241
+  gh app-auth debug list-repositories --client-id Iv1.your_client_id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
 				return fmt.Errorf("failed to load configuration: %w", err)
 			}
 
-			apps := make([]*config.GitHubApp, 0, len(cfg.GitHubApps))
-			if cmd.Flags().Changed("app-id") {
-				for i := range cfg.GitHubApps {
-					if cfg.GitHubApps[i].AppID == appID {
-						apps = append(apps, &cfg.GitHubApps[i])
-						break
-					}
-				}
-				if len(apps) == 0 {
-					return fmt.Errorf("app with ID %d not found in configuration", appID)
-				}
-			} else {
-				for i := range cfg.GitHubApps {
-					apps = append(apps, &cfg.GitHubApps[i])
-				}
-				if len(apps) == 0 {
-					fmt.Println("No GitHub Apps configured. Run 'gh app-auth setup' to add one.")
-					return nil
-				}
+			appIDSet := cmd.Flags().Changed("app-id")
+			clientIDSet := cmd.Flags().Changed("client-id")
+			apps, err := selectDebugApps(cfg, appID, clientID, appIDSet, clientIDSet)
+			if err != nil {
+				return err
+			}
+			if len(apps) == 0 {
+				fmt.Println("No GitHub Apps configured. Run 'gh app-auth setup' to add one.")
+				return nil
 			}
 
+			filtered := appIDSet || clientIDSet
+
 			for idx, app := range apps {
-				fmt.Printf("=== %s (App ID %d) ===\n", appDisplayName(app), app.AppID)
+				fmt.Printf("=== %s (App ID: %s) ===\n", appDisplayName(app), app.GetIdentifier())
 
 				if app.InstallationID == 0 {
-					err := fmt.Errorf("app %d does not have an installation_id configured", app.AppID)
-					if cmd.Flags().Changed("app-id") {
+					err := fmt.Errorf("app %s does not have an installation_id configured", app.GetIdentifier())
+					if filtered {
 						return err
 					}
 					fmt.Printf("  Error: %v\n\n", err)
@@ -165,8 +158,8 @@ func newListInstallationReposCmd() *cobra.Command {
 				}
 
 				if len(app.Patterns) == 0 {
-					err := fmt.Errorf("app %d has no patterns configured", app.AppID)
-					if cmd.Flags().Changed("app-id") {
+					err := fmt.Errorf("app %s has no patterns configured", app.GetIdentifier())
+					if filtered {
 						return err
 					}
 					fmt.Printf("  Error: %v\n\n", err)
@@ -176,7 +169,7 @@ func newListInstallationReposCmd() *cobra.Command {
 				host := extractHostFromPattern(app.Patterns[0])
 				if host == "" {
 					err := fmt.Errorf("unable to determine host from pattern %q", app.Patterns[0])
-					if cmd.Flags().Changed("app-id") {
+					if filtered {
 						return err
 					}
 					fmt.Printf("  Error: %v\n\n", err)
@@ -186,8 +179,8 @@ func newListInstallationReposCmd() *cobra.Command {
 				authenticator := auth.NewAuthenticator()
 				jwtToken, err := authenticator.GenerateJWTForApp(app)
 				if err != nil {
-					if cmd.Flags().Changed("app-id") {
-						return fmt.Errorf("failed to generate JWT for app %d: %w", app.AppID, err)
+					if filtered {
+						return fmt.Errorf("failed to generate JWT for app %s: %w", app.GetIdentifier(), err)
 					}
 					fmt.Printf("  Error: %v\n\n", err)
 					continue
@@ -196,8 +189,8 @@ func newListInstallationReposCmd() *cobra.Command {
 				repoURL := fmt.Sprintf("https://%s", host)
 				installationToken, err := authenticator.GetInstallationToken(jwtToken, app.InstallationID, repoURL)
 				if err != nil {
-					if cmd.Flags().Changed("app-id") {
-						return fmt.Errorf("failed to obtain installation token for app %d: %w", app.AppID, err)
+					if filtered {
+						return fmt.Errorf("failed to obtain installation token for app %s: %w", app.GetIdentifier(), err)
 					}
 					fmt.Printf("  Error obtaining installation token: %v\n\n", err)
 					continue
@@ -205,7 +198,7 @@ func newListInstallationReposCmd() *cobra.Command {
 
 				repos, err := listInstallationRepositories(installationToken, host)
 				if err != nil {
-					if cmd.Flags().Changed("app-id") {
+					if filtered {
 						return err
 					}
 					fmt.Printf("  Error listing repositories: %v\n\n", err)
@@ -238,9 +231,54 @@ func newListInstallationReposCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Int64Var(&appID, "app-id", 0, "GitHub App ID (optional)")
+	cmd.Flags().Int64Var(&appID, "app-id", 0, "GitHub App ID (optional, mutually exclusive with --client-id)")
+	cmd.Flags().StringVar(&clientID, "client-id", "", "GitHub App Client ID (optional, mutually exclusive with --app-id)")
 
 	return cmd
+}
+
+// selectDebugApps returns the apps to inspect based on the --app-id and --client-id flags.
+// At most one of the flags may be set.
+func selectDebugApps(
+	cfg *config.Config,
+	appID int64,
+	clientID string,
+	appIDSet, clientIDSet bool,
+) ([]*config.GitHubApp, error) {
+	if appIDSet && clientIDSet {
+		return nil, fmt.Errorf("use only one of --app-id or --client-id")
+	}
+
+	if appIDSet && appID < 0 {
+		return nil, fmt.Errorf("app-id must be positive")
+	}
+
+	if clientIDSet && clientID == "" {
+		return nil, fmt.Errorf("client-id cannot be empty")
+	}
+
+	if !appIDSet && !clientIDSet {
+		apps := make([]*config.GitHubApp, 0, len(cfg.GitHubApps))
+		for i := range cfg.GitHubApps {
+			apps = append(apps, &cfg.GitHubApps[i])
+		}
+		return apps, nil
+	}
+
+	for i := range cfg.GitHubApps {
+		app := &cfg.GitHubApps[i]
+		if clientIDSet && app.ClientID == clientID {
+			return []*config.GitHubApp{app}, nil
+		}
+		if appIDSet && app.AppID == appID {
+			return []*config.GitHubApp{app}, nil
+		}
+	}
+
+	if clientIDSet {
+		return nil, fmt.Errorf("app with client ID %s not found in configuration", clientID)
+	}
+	return nil, fmt.Errorf("app with ID %d not found in configuration", appID)
 }
 
 type installation struct {
@@ -362,7 +400,7 @@ func extractHostFromPattern(pattern string) string {
 func appDisplayName(app *config.GitHubApp) string {
 	name := strings.TrimSpace(app.Name)
 	if name == "" {
-		return fmt.Sprintf("GitHub App %d", app.AppID)
+		return fmt.Sprintf("GitHub App %s", app.GetIdentifier())
 	}
 	return name
 }

--- a/cmd/debug_test.go
+++ b/cmd/debug_test.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
+	"gopkg.in/yaml.v3"
 )
 
 func TestSelectDebugApps(t *testing.T) {
@@ -124,5 +128,203 @@ func TestNewDebugCmd_Flags(t *testing.T) {
 	}
 	if listRepos.Flags().Lookup("app-id") == nil {
 		t.Error("list-repositories should define --app-id flag")
+	}
+}
+
+func writeDebugTestConfig(t *testing.T, cfg *config.Config) string {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yml")
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Failed to marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, data, 0600); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	return configPath
+}
+
+func debugTestApp(t *testing.T) string {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "test-key.pem")
+	testKey := generateTestRSAKey(t)
+	if err := os.WriteFile(keyPath, []byte(testKey), 0600); err != nil {
+		t.Fatalf("Failed to write test key: %v", err)
+	}
+
+	cfg := &config.Config{
+		Version: "1.0",
+		GitHubApps: []config.GitHubApp{
+			{
+				Name:             "Debug Client App",
+				ClientID:         "Iv1.DebugClient",
+				InstallationID:   789012,
+				Patterns:         []string{"github.com/org/*"},
+				PrivateKeySource: config.PrivateKeySourceFilesystem,
+				PrivateKeyPath:   keyPath,
+			},
+		},
+	}
+
+	return writeDebugTestConfig(t, cfg)
+}
+
+func TestDebugListInstallationsCmd_RunE(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	t.Run("no apps configured", func(t *testing.T) {
+		cfg := &config.Config{
+			Version: "1.0",
+			PATs: []config.PersonalAccessToken{
+				{Name: "Test PAT", Patterns: []string{"github.com/test/*"}},
+			},
+		}
+		configPath := writeDebugTestConfig(t, cfg)
+		t.Setenv("GH_APP_AUTH_CONFIG", configPath)
+
+		cmd := newListInstallationsCmd()
+		var stdout bytes.Buffer
+		cmd.SetOut(&stdout)
+		cmd.SetErr(&stdout)
+
+		err := cmd.Execute()
+		if err != nil {
+			t.Errorf("Command failed: %v", err)
+		}
+	})
+
+	t.Run("client id not found", func(t *testing.T) {
+		configPath := debugTestApp(t)
+		t.Setenv("GH_APP_AUTH_CONFIG", configPath)
+
+		cmd := newListInstallationsCmd()
+		cmd.SetArgs([]string{"--client-id", "Iv1.NotFound"})
+
+		err := cmd.Execute()
+		if err == nil {
+			t.Error("Expected error for non-existent client ID")
+		}
+	})
+
+	t.Run("client id filter hits and fails network", func(t *testing.T) {
+		configPath := debugTestApp(t)
+		t.Setenv("GH_APP_AUTH_CONFIG", configPath)
+
+		cmd := newListInstallationsCmd()
+		cmd.SetArgs([]string{"--client-id", "Iv1.DebugClient"})
+
+		err := cmd.Execute()
+		if err == nil {
+			t.Error("Expected network error when listing installations")
+		}
+	})
+
+	t.Run("no filter iterates apps and fails network", func(t *testing.T) {
+		configPath := debugTestApp(t)
+		t.Setenv("GH_APP_AUTH_CONFIG", configPath)
+
+		cmd := newListInstallationsCmd()
+		var stdout bytes.Buffer
+		cmd.SetOut(&stdout)
+		cmd.SetErr(&stdout)
+
+		err := cmd.Execute()
+		if err != nil {
+			t.Errorf("Unfiltered command should continue on network errors: %v", err)
+		}
+	})
+}
+
+func TestDebugListRepositoriesCmd_RunE(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	t.Run("client id filter hits and fails network", func(t *testing.T) {
+		configPath := debugTestApp(t)
+		t.Setenv("GH_APP_AUTH_CONFIG", configPath)
+
+		cmd := newListInstallationReposCmd()
+		cmd.SetArgs([]string{"--client-id", "Iv1.DebugClient"})
+
+		err := cmd.Execute()
+		if err == nil {
+			t.Error("Expected network error when listing repositories")
+		}
+	})
+
+	t.Run("no filter iterates apps and fails network", func(t *testing.T) {
+		configPath := debugTestApp(t)
+		t.Setenv("GH_APP_AUTH_CONFIG", configPath)
+
+		cmd := newListInstallationReposCmd()
+		var stdout bytes.Buffer
+		cmd.SetOut(&stdout)
+		cmd.SetErr(&stdout)
+
+		err := cmd.Execute()
+		if err != nil {
+			t.Errorf("Unfiltered command should continue on network errors: %v", err)
+		}
+	})
+}
+
+func TestAppDisplayName(t *testing.T) {
+	tests := []struct {
+		name string
+		app  config.GitHubApp
+		want string
+	}{
+		{
+			name: "with name",
+			app:  config.GitHubApp{Name: "My App", AppID: 123456},
+			want: "My App",
+		},
+		{
+			name: "client id fallback",
+			app:  config.GitHubApp{ClientID: "Iv1.Fallback"},
+			want: "GitHub App Iv1.Fallback",
+		},
+		{
+			name: "app id fallback",
+			app:  config.GitHubApp{AppID: 123456},
+			want: "GitHub App 123456",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appDisplayName(&tt.app); got != tt.want {
+				t.Errorf("appDisplayName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractHostFromPattern(t *testing.T) {
+	tests := []struct {
+		pattern string
+		want    string
+	}{
+		{"github.com/org/*", "github.com"},
+		{"https://github.example.com/org/repo", "github.example.com"},
+		{"  http://host/path  ", "host"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern, func(t *testing.T) {
+			if got := extractHostFromPattern(tt.pattern); got != tt.want {
+				t.Errorf("extractHostFromPattern(%q) = %q, want %q", tt.pattern, got, tt.want)
+			}
+		})
 	}
 }

--- a/cmd/debug_test.go
+++ b/cmd/debug_test.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
+)
+
+func TestSelectDebugApps(t *testing.T) {
+	cfg := &config.Config{
+		Version: "1.0",
+		GitHubApps: []config.GitHubApp{
+			{Name: "App1", AppID: 111111},
+			{Name: "App2", AppID: 222222, ClientID: "Iv1.ClientTwo"},
+			{Name: "App3", AppID: 333333},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		appID       int64
+		clientID    string
+		appIDSet    bool
+		clientIDSet bool
+		wantCount   int
+		wantName    string
+		wantErr     bool
+	}{
+		{
+			name:      "all apps when no filter",
+			wantCount: 3,
+		},
+		{
+			name:      "filter by app id",
+			appID:     111111,
+			appIDSet:  true,
+			wantCount: 1,
+			wantName:  "App1",
+		},
+		{
+			name:        "filter by client id",
+			clientID:    "Iv1.ClientTwo",
+			clientIDSet: true,
+			wantCount:   1,
+			wantName:    "App2",
+		},
+		{
+			name:      "app id not found",
+			appID:     999999,
+			appIDSet:  true,
+			wantCount: 0,
+			wantErr:   true,
+		},
+		{
+			name:        "client id not found",
+			clientID:    "Iv1.NotFound",
+			clientIDSet: true,
+			wantCount:   0,
+			wantErr:     true,
+		},
+		{
+			name:        "both flags set",
+			appID:       111111,
+			appIDSet:    true,
+			clientID:    "Iv1.ClientTwo",
+			clientIDSet: true,
+			wantCount:   0,
+			wantErr:     true,
+		},
+		{
+			name:        "empty client id",
+			clientIDSet: true,
+			wantCount:   0,
+			wantErr:     true,
+		},
+		{
+			name:      "negative app id",
+			appID:     -1,
+			appIDSet:  true,
+			wantCount: 0,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apps, err := selectDebugApps(cfg, tt.appID, tt.clientID, tt.appIDSet, tt.clientIDSet)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if len(apps) != tt.wantCount {
+				t.Errorf("Got %d apps, want %d", len(apps), tt.wantCount)
+			}
+
+			if tt.wantCount == 1 && apps[0].Name != tt.wantName {
+				t.Errorf("App name = %q, want %q", apps[0].Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestNewDebugCmd_Flags(t *testing.T) {
+	listInstallations := newListInstallationsCmd()
+	if listInstallations.Flags().Lookup("client-id") == nil {
+		t.Error("list-installations should define --client-id flag")
+	}
+	if listInstallations.Flags().Lookup("app-id") == nil {
+		t.Error("list-installations should define --app-id flag")
+	}
+
+	listRepos := newListInstallationReposCmd()
+	if listRepos.Flags().Lookup("client-id") == nil {
+		t.Error("list-repositories should define --client-id flag")
+	}
+	if listRepos.Flags().Lookup("app-id") == nil {
+		t.Error("list-repositories should define --app-id flag")
+	}
+}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,0 +1,397 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/AmadeusITGroup/gh-app-auth/pkg/auth"
+	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
+	"github.com/AmadeusITGroup/gh-app-auth/pkg/matcher"
+	"github.com/cli/go-gh/v2/pkg/repository"
+	"github.com/spf13/cobra"
+)
+
+type execCredentialRequest struct {
+	Repository     string
+	AppID          int64
+	InstallationID int64
+}
+
+type execCredential struct {
+	Token      string
+	Host       string
+	Repository string
+}
+
+type execCredentialResolver func(execCredentialRequest) (execCredential, error)
+
+type execCommandRunner func(
+	context.Context,
+	string,
+	[]string,
+	[]string,
+	io.Reader,
+	io.Writer,
+	io.Writer,
+) error
+
+func NewExecCmd() *cobra.Command {
+	return newExecCmd(resolveExecCredential, runExecCommand)
+}
+
+func newExecCmd(resolveCredential execCredentialResolver, runCommand execCommandRunner) *cobra.Command {
+	var (
+		repoFlag           string
+		appIDFlag          int64
+		installationIDFlag int64
+	)
+
+	cmd := &cobra.Command{
+		Use:   "exec [flags] -- <command> [args...]",
+		Short: "Run a command with managed GitHub authentication",
+		Long: `Run a command with a short-lived token from a configured GitHub App
+or PAT. Select credentials by repository, App ID, or installation ID. The token
+is exposed only to the child process through the environment and is never
+printed by gh-app-auth.`,
+		Example: `  # Call the GitHub API for the current repository
+  gh app-auth exec -- gh api repos/{owner}/{repo}
+
+  # Run a gh command outside a repository
+  gh app-auth exec --repo github.com/myorg/myrepo -- gh pr list
+
+  # Run a repository-independent API command as a configured App installation
+  gh app-auth exec --app-id 123456 --installation-id 789012 -- gh api /installation/repositories`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("app-id") && appIDFlag <= 0 {
+				return fmt.Errorf("app ID must be positive")
+			}
+			if cmd.Flags().Changed("installation-id") && installationIDFlag <= 0 {
+				return fmt.Errorf("installation ID must be positive")
+			}
+
+			request, err := newExecCredentialRequest(repoFlag, appIDFlag, installationIDFlag)
+			if err != nil {
+				return err
+			}
+
+			credential, err := resolveCredential(request)
+			if err != nil {
+				return err
+			}
+
+			env := execEnvironment(os.Environ(), credential)
+			err = runCommand(
+				cmd.Context(),
+				args[0],
+				args[1:],
+				env,
+				cmd.InOrStdin(),
+				cmd.OutOrStdout(),
+				cmd.ErrOrStderr(),
+			)
+			if err != nil {
+				cmd.Root().SilenceErrors = true
+				cmd.Root().SilenceUsage = true
+			}
+			return err
+		},
+	}
+
+	cmd.Flags().StringVarP(
+		&repoFlag,
+		"repo",
+		"R",
+		"",
+		"Repository to authenticate for (default: current repository unless an ID selector is used)",
+	)
+	cmd.Flags().Int64Var(&appIDFlag, "app-id", 0, "Configured GitHub App ID to authenticate with")
+	cmd.Flags().Int64Var(&installationIDFlag, "installation-id", 0, "GitHub App installation ID to authenticate with")
+
+	return cmd
+}
+
+func newExecCredentialRequest(repoURL string, appID, installationID int64) (execCredentialRequest, error) {
+	if appID < 0 {
+		return execCredentialRequest{}, fmt.Errorf("app ID must be positive")
+	}
+	if installationID < 0 {
+		return execCredentialRequest{}, fmt.Errorf("installation ID must be positive")
+	}
+
+	if repoURL == "" && appID == 0 && installationID == 0 {
+		var err error
+		repoURL, err = determineRepositoryURL("")
+		if err != nil {
+			return execCredentialRequest{}, err
+		}
+	}
+
+	if repoURL != "" {
+		repo, err := repository.Parse(repoURL)
+		if err != nil {
+			return execCredentialRequest{}, fmt.Errorf("failed to parse repository %q: %w", repoURL, err)
+		}
+		repoURL = fmt.Sprintf("%s/%s/%s", repo.Host, repo.Owner, repo.Name)
+	}
+
+	return execCredentialRequest{
+		Repository:     repoURL,
+		AppID:          appID,
+		InstallationID: installationID,
+	}, nil
+}
+
+func resolveExecCredential(request execCredentialRequest) (execCredential, error) {
+	cfg, err := loadCredentialConfig()
+	if err != nil {
+		return execCredential{}, err
+	}
+
+	if request.AppID == 0 && request.InstallationID == 0 {
+		return resolveRepositoryCredential(cfg, request.Repository)
+	}
+
+	selectedApp, err := selectExecApp(cfg, request)
+	if err != nil {
+		return execCredential{}, err
+	}
+
+	app := *selectedApp
+	if request.InstallationID != 0 {
+		app.InstallationID = request.InstallationID
+	}
+
+	host, tokenTarget, err := execCredentialTarget(app, request.Repository)
+	if err != nil {
+		return execCredential{}, err
+	}
+
+	token, _, err := auth.NewAuthenticator().GetCredentials(&app, tokenTarget)
+	if err != nil {
+		return execCredential{}, fmt.Errorf("failed to get GitHub App credentials: %w", err)
+	}
+
+	return execCredential{Token: token, Host: host, Repository: request.Repository}, nil
+}
+
+func execCredentialTarget(app config.GitHubApp, repoURL string) (string, string, error) {
+	if repoURL != "" {
+		repo, err := repository.Parse(repoURL)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to parse repository %q: %w", repoURL, err)
+		}
+		return repo.Host, repoURL, nil
+	}
+
+	if app.InstallationID == 0 {
+		return "", "", fmt.Errorf("selected GitHub App has no installation ID; use --installation-id or --repo")
+	}
+	host, err := inferExecHost(app.Patterns)
+	if err != nil {
+		return "", "", err
+	}
+	return host, host, nil
+}
+
+func resolveRepositoryCredential(cfg *config.Config, repoURL string) (execCredential, error) {
+	matchedApp, matchedPAT, err := findMatchingCredential(cfg, repoURL)
+	if err != nil {
+		return execCredential{}, err
+	}
+	if matchedApp == nil && matchedPAT == nil {
+		return execCredential{}, fmt.Errorf("no credential configured for %s; run 'gh app-auth setup' first", repoURL)
+	}
+
+	repo, err := repository.Parse(repoURL)
+	if err != nil {
+		return execCredential{}, fmt.Errorf("failed to parse repository %q: %w", repoURL, err)
+	}
+
+	if matchedPAT != nil {
+		secretManager, managerErr := newDefaultSecretsManager()
+		if managerErr != nil {
+			return execCredential{}, managerErr
+		}
+		token, tokenErr := matchedPAT.GetPAT(secretManager)
+		if tokenErr != nil {
+			return execCredential{}, fmt.Errorf("failed to get PAT: %w", tokenErr)
+		}
+		return execCredential{Token: token, Host: repo.Host, Repository: repoURL}, nil
+	}
+
+	token, _, err := auth.NewAuthenticator().GetCredentials(matchedApp, repoURL)
+	if err != nil {
+		return execCredential{}, fmt.Errorf("failed to get GitHub App credentials: %w", err)
+	}
+	return execCredential{Token: token, Host: repo.Host, Repository: repoURL}, nil
+}
+
+func selectExecApp(cfg *config.Config, request execCredentialRequest) (*config.GitHubApp, error) {
+	candidates := execAppCandidates(cfg.GitHubApps, request)
+	if len(candidates) == 0 {
+		return nil, execAppNotFoundError(request)
+	}
+	if len(candidates) == 1 {
+		return &candidates[0], nil
+	}
+
+	if request.Repository != "" {
+		matchedApp, err := matcher.NewMatcher(candidates).Match(request.Repository)
+		if err != nil {
+			return nil, fmt.Errorf("failed to match selected GitHub App to repository: %w", err)
+		}
+		if matchedApp != nil {
+			return matchedApp, nil
+		}
+	}
+
+	return nil, ambiguousExecAppError(request)
+}
+
+func execAppCandidates(apps []config.GitHubApp, request execCredentialRequest) []config.GitHubApp {
+	candidates := matchingExecApps(apps, request)
+	if request.AppID == 0 || request.InstallationID == 0 {
+		return candidates
+	}
+
+	exact := matchingExecInstallations(candidates, request.InstallationID)
+	if len(exact) > 0 {
+		return exact
+	}
+	return candidates
+}
+
+func matchingExecApps(apps []config.GitHubApp, request execCredentialRequest) []config.GitHubApp {
+	candidates := make([]config.GitHubApp, 0, len(apps))
+	for _, app := range apps {
+		if request.AppID != 0 && app.AppID != request.AppID {
+			continue
+		}
+		if request.AppID == 0 && request.InstallationID != 0 && app.InstallationID != request.InstallationID {
+			continue
+		}
+		candidates = append(candidates, app)
+	}
+	return candidates
+}
+
+func matchingExecInstallations(apps []config.GitHubApp, installationID int64) []config.GitHubApp {
+	matches := make([]config.GitHubApp, 0, len(apps))
+	for _, app := range apps {
+		if app.InstallationID == installationID {
+			matches = append(matches, app)
+		}
+	}
+	return matches
+}
+
+func execAppNotFoundError(request execCredentialRequest) error {
+	switch {
+	case request.AppID != 0 && request.InstallationID != 0:
+		return fmt.Errorf(
+			"no configured GitHub App matches app ID %d and installation ID %d",
+			request.AppID,
+			request.InstallationID,
+		)
+	case request.AppID != 0:
+		return fmt.Errorf("no configured GitHub App matches app ID %d", request.AppID)
+	default:
+		return fmt.Errorf("no configured GitHub App matches installation ID %d", request.InstallationID)
+	}
+}
+
+func ambiguousExecAppError(request execCredentialRequest) error {
+	switch {
+	case request.AppID != 0 && request.InstallationID != 0:
+		return fmt.Errorf("multiple GitHub App configurations match; use --repo to disambiguate the host")
+	case request.AppID != 0:
+		return fmt.Errorf("multiple GitHub App configurations match; use --installation-id or --repo")
+	default:
+		return fmt.Errorf("multiple GitHub App configurations match; use --app-id or --repo")
+	}
+}
+
+func inferExecHost(patterns []string) (string, error) {
+	host := ""
+	for _, pattern := range patterns {
+		candidate := strings.TrimSpace(pattern)
+		if candidate == "" {
+			continue
+		}
+
+		info, err := matcher.GetRepositoryInfo(candidate)
+		if err == nil {
+			candidate = info.Host
+		} else {
+			candidate = strings.TrimPrefix(candidate, "https://")
+			candidate = strings.TrimPrefix(candidate, "http://")
+			candidate = strings.TrimSuffix(candidate, "/")
+			if strings.Contains(candidate, "/") || strings.ContainsAny(candidate, "*") {
+				return "", fmt.Errorf("cannot infer host from GitHub App pattern %q; use --repo", pattern)
+			}
+		}
+
+		if host != "" && candidate != host {
+			return "", fmt.Errorf("selected GitHub App spans multiple hosts; use --repo")
+		}
+		host = candidate
+	}
+
+	if host == "" {
+		return "", fmt.Errorf("selected GitHub App has no host pattern; use --repo")
+	}
+	return host, nil
+}
+
+func execEnvironment(current []string, credential execCredential) []string {
+	blocked := map[string]struct{}{
+		"GH_TOKEN":                {},
+		"GITHUB_TOKEN":            {},
+		"GH_ENTERPRISE_TOKEN":     {},
+		"GITHUB_ENTERPRISE_TOKEN": {},
+		"GH_HOST":                 {},
+		"GH_REPO":                 {},
+	}
+
+	env := make([]string, 0, len(current)+3)
+	for _, entry := range current {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, found := blocked[key]; !found {
+			env = append(env, entry)
+		}
+	}
+
+	tokenVariable := "GH_ENTERPRISE_TOKEN"
+	if credential.Host == gitHubAPIHost || strings.HasSuffix(credential.Host, ".ghe.com") {
+		tokenVariable = "GH_TOKEN"
+	}
+
+	env = append(env, tokenVariable+"="+credential.Token, "GH_HOST="+credential.Host)
+	if credential.Repository != "" {
+		env = append(env, "GH_REPO="+credential.Repository)
+	}
+	return env
+}
+
+func runExecCommand(
+	ctx context.Context,
+	name string,
+	args []string,
+	env []string,
+	stdin io.Reader,
+	stdout io.Writer,
+	stderr io.Writer,
+) error {
+	// #nosec G204 -- The user explicitly selects the command, which is executed directly without a shell.
+	child := exec.CommandContext(ctx, name, args...)
+	child.Env = env
+	child.Stdin = stdin
+	child.Stdout = stdout
+	child.Stderr = stderr
+	return child.Run()
+}

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -1,0 +1,353 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
+)
+
+func TestExecCommand(t *testing.T) {
+	t.Run("repository routing", func(t *testing.T) {
+		var (
+			resolvedRequest execCredentialRequest
+			runName         string
+			runArgs         []string
+			runEnv          []string
+		)
+
+		cmd := newExecCmd(
+			func(request execCredentialRequest) (execCredential, error) {
+				resolvedRequest = request
+				return execCredential{
+					Token:      "secret-token",
+					Host:       gitHubAPIHost,
+					Repository: request.Repository,
+				}, nil
+			},
+			func(
+				_ context.Context,
+				name string,
+				args []string,
+				env []string,
+				_ io.Reader,
+				_ io.Writer,
+				_ io.Writer,
+			) error {
+				runName = name
+				runArgs = args
+				runEnv = env
+				return nil
+			},
+		)
+		cmd.SetArgs([]string{"--repo", "github.com/myorg/myrepo", "--", "gh", "api", "repos/{owner}/{repo}"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if resolvedRequest.Repository != "github.com/myorg/myrepo" {
+			t.Errorf("resolved repository = %q, want %q", resolvedRequest.Repository, "github.com/myorg/myrepo")
+		}
+		if runName != "gh" {
+			t.Errorf("command name = %q, want %q", runName, "gh")
+		}
+		if got := strings.Join(runArgs, " "); got != "api repos/{owner}/{repo}" {
+			t.Errorf("command args = %q, want %q", got, "api repos/{owner}/{repo}")
+		}
+		assertEnvironmentValue(t, runEnv, "GH_TOKEN", "secret-token")
+		assertEnvironmentValue(t, runEnv, "GH_HOST", gitHubAPIHost)
+		assertEnvironmentValue(t, runEnv, "GH_REPO", "github.com/myorg/myrepo")
+	})
+
+	t.Run("repository-independent App routing", func(t *testing.T) {
+		var resolvedRequest execCredentialRequest
+		var runEnv []string
+
+		cmd := newExecCmd(
+			func(request execCredentialRequest) (execCredential, error) {
+				resolvedRequest = request
+				return execCredential{Token: "app-token", Host: gitHubAPIHost}, nil
+			},
+			func(
+				_ context.Context,
+				_ string,
+				_ []string,
+				env []string,
+				_ io.Reader,
+				_ io.Writer,
+				_ io.Writer,
+			) error {
+				runEnv = env
+				return nil
+			},
+		)
+		cmd.SetArgs([]string{
+			"--app-id", "123456",
+			"--installation-id", "789012",
+			"--", "gh", "api", "/installation/repositories",
+		})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if resolvedRequest.Repository != "" {
+			t.Errorf("resolved repository = %q, want empty", resolvedRequest.Repository)
+		}
+		if resolvedRequest.AppID != 123456 || resolvedRequest.InstallationID != 789012 {
+			t.Errorf("resolved IDs = (%d, %d), want (123456, 789012)", resolvedRequest.AppID, resolvedRequest.InstallationID)
+		}
+		assertEnvironmentValue(t, runEnv, "GH_TOKEN", "app-token")
+		assertEnvironmentValue(t, runEnv, "GH_HOST", gitHubAPIHost)
+		assertEnvironmentMissing(t, runEnv, "GH_REPO")
+	})
+}
+
+func TestExecCommandRejectsNonPositiveSelectors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "zero App ID", args: []string{"--app-id", "0", "--", "gh", "api", "user"}},
+		{name: "negative App ID", args: []string{"--app-id", "-1", "--", "gh", "api", "user"}},
+		{name: "zero installation ID", args: []string{"--installation-id", "0", "--", "gh", "api", "user"}},
+		{name: "negative installation ID", args: []string{"--installation-id", "-1", "--", "gh", "api", "user"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newExecCmd(
+				func(execCredentialRequest) (execCredential, error) {
+					t.Fatal("resolver should not be called")
+					return execCredential{}, nil
+				},
+				func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
+					t.Fatal("runner should not be called")
+					return nil
+				},
+			)
+			cmd.SetArgs(tt.args)
+
+			if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "must be positive") {
+				t.Fatalf("Execute() error = %v, want positive-value error", err)
+			}
+		})
+	}
+}
+
+func TestExecCommandPropagatesErrors(t *testing.T) {
+	t.Run("credential resolution", func(t *testing.T) {
+		wantErr := errors.New("token unavailable")
+		cmd := newExecCmd(
+			func(execCredentialRequest) (execCredential, error) { return execCredential{}, wantErr },
+			func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
+				t.Fatal("runner should not be called")
+				return nil
+			},
+		)
+		cmd.SetArgs([]string{"--repo", "github.com/myorg/myrepo", "--", "gh", "api", "user"})
+
+		if err := cmd.Execute(); !errors.Is(err, wantErr) {
+			t.Fatalf("Execute() error = %v, want %v", err, wantErr)
+		}
+	})
+
+	t.Run("child process", func(t *testing.T) {
+		wantErr := errors.New("child failed")
+		cmd := newExecCmd(
+			func(request execCredentialRequest) (execCredential, error) {
+				return execCredential{Token: "secret-token", Host: gitHubAPIHost, Repository: request.Repository}, nil
+			},
+			func(context.Context, string, []string, []string, io.Reader, io.Writer, io.Writer) error {
+				return wantErr
+			},
+		)
+		cmd.SetArgs([]string{"--repo", "github.com/myorg/myrepo", "--", "gh", "api", "user"})
+
+		if err := cmd.Execute(); !errors.Is(err, wantErr) {
+			t.Fatalf("Execute() error = %v, want %v", err, wantErr)
+		}
+		if !cmd.SilenceErrors || !cmd.SilenceUsage {
+			t.Fatal("child failures should not print an error or command usage")
+		}
+	})
+}
+
+func TestSelectExecApp(t *testing.T) {
+	cfg := &config.Config{GitHubApps: []config.GitHubApp{
+		{Name: "org-a", AppID: 100, InstallationID: 200, Patterns: []string{"github.com/org-a/*"}},
+		{Name: "org-b", AppID: 100, InstallationID: 300, Patterns: []string{"github.com/org-b/*"}},
+		{Name: "enterprise", AppID: 400, InstallationID: 500, Patterns: []string{"github.example.com/org/*"}},
+	}}
+
+	tests := []struct {
+		name        string
+		request     execCredentialRequest
+		wantName    string
+		wantErrText string
+	}{
+		{
+			name:     "installation ID",
+			request:  execCredentialRequest{InstallationID: 300},
+			wantName: "org-b",
+		},
+		{
+			name:     "App and installation ID",
+			request:  execCredentialRequest{AppID: 100, InstallationID: 200},
+			wantName: "org-a",
+		},
+		{
+			name:     "repository disambiguates App ID",
+			request:  execCredentialRequest{Repository: "github.com/org-b/repo", AppID: 100},
+			wantName: "org-b",
+		},
+		{
+			name:        "ambiguous App ID",
+			request:     execCredentialRequest{AppID: 100},
+			wantErrText: "multiple GitHub App configurations match",
+		},
+		{
+			name:        "unknown installation",
+			request:     execCredentialRequest{InstallationID: 999},
+			wantErrText: "no configured GitHub App matches",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app, err := selectExecApp(cfg, tt.request)
+			if tt.wantErrText != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("selectExecApp() error = %v, want containing %q", err, tt.wantErrText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("selectExecApp() error = %v", err)
+			}
+			if app.Name != tt.wantName {
+				t.Errorf("selected app = %q, want %q", app.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestInferExecHost(t *testing.T) {
+	tests := []struct {
+		name        string
+		patterns    []string
+		want        string
+		wantErrText string
+	}{
+		{
+			name:     "same host",
+			patterns: []string{"github.com/org-a/*", "https://github.com/org-b/*"},
+			want:     gitHubAPIHost,
+		},
+		{
+			name:        "multiple hosts",
+			patterns:    []string{"github.com/org/*", "github.example.com/org/*"},
+			wantErrText: "spans multiple hosts",
+		},
+		{
+			name:        "no patterns",
+			wantErrText: "has no host pattern",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := inferExecHost(tt.patterns)
+			if tt.wantErrText != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("inferExecHost() error = %v, want containing %q", err, tt.wantErrText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("inferExecHost() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("inferExecHost() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecEnvironment(t *testing.T) {
+	t.Run("github.com repository", func(t *testing.T) {
+		env := execEnvironment(
+			[]string{
+				"PATH=/usr/bin",
+				"GH_TOKEN=old-gh-token",
+				"GITHUB_TOKEN=old-github-token",
+				"GH_ENTERPRISE_TOKEN=old-enterprise-token",
+				"GITHUB_ENTERPRISE_TOKEN=old-github-enterprise-token",
+				"GH_HOST=old.example.com",
+				"GH_REPO=old/repo",
+			},
+			execCredential{
+				Token:      "new-token",
+				Host:       gitHubAPIHost,
+				Repository: "github.com/myorg/myrepo",
+			},
+		)
+
+		assertEnvironmentValue(t, env, "PATH", "/usr/bin")
+		assertEnvironmentValue(t, env, "GH_TOKEN", "new-token")
+		assertEnvironmentValue(t, env, "GH_HOST", gitHubAPIHost)
+		assertEnvironmentValue(t, env, "GH_REPO", "github.com/myorg/myrepo")
+		assertEnvironmentMissing(t, env, "GITHUB_TOKEN")
+		assertEnvironmentMissing(t, env, "GH_ENTERPRISE_TOKEN")
+		assertEnvironmentMissing(t, env, "GITHUB_ENTERPRISE_TOKEN")
+	})
+
+	t.Run("GitHub Enterprise Server without repository", func(t *testing.T) {
+		env := execEnvironment(
+			nil,
+			execCredential{Token: "enterprise-token", Host: "github.example.com"},
+		)
+
+		assertEnvironmentValue(t, env, "GH_ENTERPRISE_TOKEN", "enterprise-token")
+		assertEnvironmentValue(t, env, "GH_HOST", "github.example.com")
+		assertEnvironmentMissing(t, env, "GH_TOKEN")
+		assertEnvironmentMissing(t, env, "GH_REPO")
+	})
+
+	t.Run("GitHub Enterprise Cloud data residency", func(t *testing.T) {
+		env := execEnvironment(
+			nil,
+			execCredential{Token: "cloud-token", Host: "octocorp.ghe.com"},
+		)
+
+		assertEnvironmentValue(t, env, "GH_TOKEN", "cloud-token")
+		assertEnvironmentMissing(t, env, "GH_ENTERPRISE_TOKEN")
+	})
+}
+
+func assertEnvironmentValue(t *testing.T, env []string, key, want string) {
+	t.Helper()
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			if got := strings.TrimPrefix(entry, prefix); got != want {
+				t.Errorf("%s = %q, want %q", key, got, want)
+			}
+			return
+		}
+	}
+	t.Errorf("%s is missing from environment", key)
+}
+
+func assertEnvironmentMissing(t *testing.T, env []string, key string) {
+	t.Helper()
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			t.Errorf("%s unexpectedly present in environment", key)
+			return
+		}
+	}
+}

--- a/cmd/git-credential.go
+++ b/cmd/git-credential.go
@@ -290,7 +290,7 @@ func findAppByPattern(cfg *config.Config, repoURL string) *config.GitHubApp {
 	for i := range cfg.GitHubApps {
 		app := &cfg.GitHubApps[i]
 		logger.FlowStep("match_by_pattern", map[string]interface{}{
-			"app_id":               app.AppID,
+			"app_identifier":       app.GetIdentifier(),
 			"app_name":             app.Name,
 			"pattern":              gitCredentialPattern,
 			"repo_url":             logger.SanitizeURL(repoURL),
@@ -300,10 +300,10 @@ func findAppByPattern(cfg *config.Config, repoURL string) *config.GitHubApp {
 		for _, pattern := range app.Patterns {
 			if matchesPattern(pattern, gitCredentialPattern) {
 				logger.FlowStep("app_matched_by_pattern", map[string]interface{}{
-					"app_id":   app.AppID,
-					"app_name": app.Name,
-					"pattern":  pattern,
-					"repo_url": logger.SanitizeURL(repoURL),
+					"app_identifier": app.GetIdentifier(),
+					"app_name":       app.Name,
+					"pattern":        pattern,
+					"repo_url":       logger.SanitizeURL(repoURL),
 				})
 				return app
 			}
@@ -351,9 +351,9 @@ func findAppByURL(cfg *config.Config, repoURL string) (*config.GitHubApp, error)
 	}
 
 	logger.FlowStep("app_matched", map[string]interface{}{
-		"app_id":   matchedApp.AppID,
-		"app_name": matchedApp.Name,
-		"patterns": matchedApp.Patterns,
+		"app_identifier": matchedApp.GetIdentifier(),
+		"app_name":       matchedApp.Name,
+		"patterns":       matchedApp.Patterns,
 	})
 
 	return matchedApp, nil
@@ -382,33 +382,52 @@ func matchesPattern(appPattern, gitCredPattern string) bool {
 	return strings.HasPrefix(normalizedPattern, normalizedAppPattern) || normalizedAppPattern == normalizedPattern
 }
 
-// doAutomaticSetup will automatically configure GitHub App if GH_APP_PRIVATE_KEY_PATH and GH_APP_ID are set
+// doAutomaticSetup will automatically configure GitHub App if GH_APP_PRIVATE_KEY_PATH and
+// either GH_APP_ID or GH_APP_CLIENT_ID are set.
 func doAutomaticSetup(repoURL string) (*config.GitHubApp, error) {
-	if os.Getenv("GH_APP_PRIVATE_KEY_PATH") != "" && os.Getenv("GH_APP_ID") != "" {
+	envAppID := os.Getenv("GH_APP_ID")
+	envClientID := os.Getenv("GH_APP_CLIENT_ID")
+	if os.Getenv("GH_APP_PRIVATE_KEY_PATH") != "" && (envAppID != "" || envClientID != "") {
 		cfg, err := config.LoadOrCreate()
 		if err != nil {
 			return nil, err
 		}
-		appId, err := strconv.ParseInt(os.Getenv("GH_APP_ID"), 10, 64)
-		if err != nil {
-			return nil, err
+
+		var appID int64
+		var clientID string
+		if envAppID != "" {
+			appID, err = strconv.ParseInt(envAppID, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			clientID = envClientID
 		}
+
 		keyFile := os.Getenv("GH_APP_PRIVATE_KEY_PATH")
 		useFileSystem := true
 		useKeyring := true
 		silent := true
 		priority := 5
 		patterns := []string{repoURL}
+
+		var identifier string
+		if clientID != "" {
+			identifier = clientID
+		} else {
+			identifier = strconv.FormatInt(appID, 10)
+		}
+
 		logger.FlowStep("automatic_setup", map[string]interface{}{
-			"app_key":       keyFile,
-			"app_id":        appId,
-			"useFileSystem": useFileSystem,
-			"keyFile":       keyFile,
-			"useKeyring":    useKeyring,
-			"patterns":      patterns,
+			"app_key":        keyFile,
+			"app_identifier": identifier,
+			"useFileSystem":  useFileSystem,
+			"keyFile":        keyFile,
+			"useKeyring":     useKeyring,
+			"patterns":       patterns,
 		})
 		return setupGitHubApp(
-			cfg, appId, keyFile, "Auto setup", 0,
+			cfg, appID, clientID, keyFile, "Auto setup", 0,
 			patterns, priority, useKeyring, useFileSystem, silent,
 		)
 	}
@@ -467,23 +486,23 @@ func generateAndOutputPATCredentials(matchedPAT *config.PersonalAccessToken) err
 // generateAndOutputCredentials generates authentication credentials and outputs them
 func generateAndOutputCredentials(matchedApp *config.GitHubApp, repoURL string) error {
 	logger.FlowStep("generate_credentials", map[string]interface{}{
-		"app_id": matchedApp.AppID,
+		"app_identifier": matchedApp.GetIdentifier(),
 	})
 
 	authenticator := auth.NewAuthenticator()
 	token, username, err := authenticator.GetCredentials(matchedApp, repoURL)
 	if err != nil {
 		logger.FlowError("generate_credentials", err, map[string]interface{}{
-			"app_id": matchedApp.AppID,
+			"app_identifier": matchedApp.GetIdentifier(),
 		})
 		return fmt.Errorf("failed to get credentials: %w", err)
 	}
 
 	logger.FlowStep("credentials_generated", map[string]interface{}{
-		"app_id":       matchedApp.AppID,
-		"username":     username,
-		"token_hash":   logger.HashToken(token),
-		"token_length": len(token),
+		"app_identifier": matchedApp.GetIdentifier(),
+		"username":       username,
+		"token_hash":     logger.HashToken(token),
+		"token_length":   len(token),
 	})
 
 	// Output credentials in git credential format

--- a/cmd/git-credential_run_test.go
+++ b/cmd/git-credential_run_test.go
@@ -2,10 +2,14 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
 	"gopkg.in/yaml.v3"
@@ -252,4 +256,101 @@ func TestHandleCredentialErase_Direct(t *testing.T) {
 			t.Errorf("handleCredentialErase should handle missing URL gracefully: %v", err)
 		}
 	})
+}
+
+func TestDoAutomaticSetup(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yml")
+	keyPath := filepath.Join(tempDir, "test-key.pem")
+
+	testKey := generateTestRSAKey(t)
+	if err := os.WriteFile(keyPath, []byte(testKey), 0600); err != nil {
+		t.Fatalf("Failed to write test key: %v", err)
+	}
+
+	t.Run("returns nil when env vars are not set", func(t *testing.T) {
+		t.Setenv("GH_APP_PRIVATE_KEY_PATH", "")
+		t.Setenv("GH_APP_ID", "")
+		t.Setenv("GH_APP_CLIENT_ID", "")
+
+		app, err := doAutomaticSetup("github.com/org/repo")
+		if err != nil {
+			t.Errorf("doAutomaticSetup() error = %v", err)
+		}
+		if app != nil {
+			t.Errorf("doAutomaticSetup() app = %v, want nil", app)
+		}
+	})
+
+	t.Run("sets up from GH_APP_CLIENT_ID", func(t *testing.T) {
+		t.Setenv("GH_APP_AUTH_CONFIG", configPath)
+		t.Setenv("GH_APP_PRIVATE_KEY_PATH", keyPath)
+		t.Setenv("GH_APP_ID", "")
+		t.Setenv("GH_APP_CLIENT_ID", "Iv1.AutoSetup")
+
+		_, err := doAutomaticSetup("github.com/org/repo")
+		// Auto-detect installation ID requires network access, so an error is expected
+		if err == nil {
+			t.Error("Expected error when auto-detecting installation ID without network")
+		}
+	})
+
+	t.Run("sets up from GH_APP_ID", func(t *testing.T) {
+		t.Setenv("GH_APP_AUTH_CONFIG", configPath)
+		t.Setenv("GH_APP_PRIVATE_KEY_PATH", keyPath)
+		t.Setenv("GH_APP_ID", "123456")
+		t.Setenv("GH_APP_CLIENT_ID", "")
+
+		_, err := doAutomaticSetup("github.com/org/repo")
+		// Auto-detect installation ID requires network access, so an error is expected
+		if err == nil {
+			t.Error("Expected error when auto-detecting installation ID without network")
+		}
+	})
+}
+
+func TestGenerateAndOutputCredentials_Success(t *testing.T) {
+	// Mock GitHub Enterprise installation token endpoint
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Expected POST, got %s", r.Method)
+		}
+
+		expectedPrefix := "/api/v3/app/installations/"
+		if !strings.HasPrefix(r.URL.Path, expectedPrefix) {
+			t.Errorf("Unexpected path: %s", r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		expiresAt := time.Now().Add(time.Hour).Format(time.RFC3339)
+		_, _ = fmt.Fprintf(w, `{"token":"mock-installation-token","expires_at":"%s"}`, expiresAt)
+	}))
+	defer server.Close()
+
+	// Make the default HTTP client trust the test TLS server
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = server.Client().Transport
+	defer func() { http.DefaultTransport = oldTransport }()
+
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "test-key.pem")
+	testKey := generateTestRSAKey(t)
+	if err := os.WriteFile(keyPath, []byte(testKey), 0600); err != nil {
+		t.Fatalf("Failed to write test key: %v", err)
+	}
+
+	app := &config.GitHubApp{
+		Name:             "Mock Server App",
+		ClientID:         "Iv1.MockServer",
+		InstallationID:   789012,
+		Patterns:         []string{"github.com/org/*"},
+		PrivateKeySource: config.PrivateKeySourceFilesystem,
+		PrivateKeyPath:   keyPath,
+	}
+
+	repoURL := fmt.Sprintf("%s/org/repo", server.URL)
+	err := generateAndOutputCredentials(app, repoURL)
+	if err != nil {
+		t.Errorf("generateAndOutputCredentials() error = %v", err)
+	}
 }

--- a/cmd/gitconfig.go
+++ b/cmd/gitconfig.go
@@ -224,7 +224,7 @@ func syncGitConfig(scope string, auto bool) error {
 	// Second pass: configure all patterns
 	for _, app := range cfg.GitHubApps {
 		for _, pattern := range app.Patterns {
-			source := fmt.Sprintf("GitHub App %s (ID: %d)", app.Name, app.AppID)
+			source := fmt.Sprintf("GitHub App %s (ID: %s)", app.Name, app.GetIdentifier())
 			configurePattern(pattern, source)
 		}
 	}

--- a/cmd/gitconfig.go
+++ b/cmd/gitconfig.go
@@ -191,8 +191,8 @@ func syncGitConfig(scope string, auto bool) error {
 	}
 
 	if auto {
-		configurePattern("github.com", "Automatic mode")
-		setUseHttpPath(scope, "github.com")
+		configurePattern(gitHubAPIHost, "Automatic mode")
+		setUseHttpPath(scope, gitHubAPIHost)
 		return nil
 	}
 

--- a/cmd/gitconfig_test.go
+++ b/cmd/gitconfig_test.go
@@ -9,6 +9,9 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
+	"gopkg.in/yaml.v3"
 )
 
 func TestNewGitConfigCmd(t *testing.T) {
@@ -534,5 +537,45 @@ func BenchmarkExtractCredentialContext_WithProtocol(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = extractCredentialContext(pattern)
+	}
+}
+
+func TestSyncGitConfig_WithClientIDApp(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	configPath := filepath.Join(tempDir, "config.yml")
+	cfg := &config.Config{
+		Version: "1.0",
+		GitHubApps: []config.GitHubApp{
+			{
+				Name:             "GitConfig Client App",
+				ClientID:         "Iv1.GitConfig",
+				InstallationID:   789012,
+				Patterns:         []string{"github.com/org/*"},
+				PrivateKeySource: config.PrivateKeySourceFilesystem,
+				PrivateKeyPath:   "/dummy/key.pem",
+			},
+		},
+	}
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Failed to marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, data, 0600); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	t.Setenv("GH_APP_AUTH_CONFIG", configPath)
+
+	err = syncGitConfig("--global", false)
+	if err != nil {
+		t.Errorf("syncGitConfig() error = %v", err)
+	}
+
+	gitConfigPath := filepath.Join(tempDir, ".gitconfig")
+	if _, err := os.Stat(gitConfigPath); os.IsNotExist(err) {
+		t.Fatal("Expected .gitconfig to be created")
 	}
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -135,7 +135,7 @@ func outputAppsTable(apps []config.GitHubApp, secretMgr *secrets.Manager, verify
 	// Add data rows
 	for _, app := range apps {
 		tp.AddField(app.Name, tableprinter.WithTruncate(nil))
-		tp.AddField(fmt.Sprintf("%d", app.AppID), tableprinter.WithTruncate(nil))
+		tp.AddField(app.GetIdentifier(), tableprinter.WithTruncate(nil))
 
 		installationDisplay := "auto-detect"
 		if app.InstallationID > 0 {
@@ -297,7 +297,7 @@ func loadListConfiguration() (*config.Config, error) {
 // outputQuietMode outputs app IDs in quiet mode
 func outputQuietMode(apps []config.GitHubApp, pats []config.PersonalAccessToken) error {
 	for _, app := range apps {
-		fmt.Printf("app:%d\n", app.AppID)
+		fmt.Printf("app:%s\n", app.GetIdentifier())
 	}
 	for _, pat := range pats {
 		fmt.Printf("pat:%s\n", pat.Name)

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -111,7 +111,7 @@ func TestOutputQuietMode(t *testing.T) {
 	apps := []config.GitHubApp{
 		{AppID: 123456},
 		{AppID: 789012},
-		{AppID: 345678},
+		{ClientID: "Iv1.Quiet"},
 	}
 	pats := []config.PersonalAccessToken{
 		{Name: "Dev PAT"},
@@ -133,6 +133,14 @@ func TestHandleOutputFormat(t *testing.T) {
 			InstallationID:   789,
 			Patterns:         []string{"github.com/org/*"},
 			Priority:         5,
+			PrivateKeySource: config.PrivateKeySourceKeyring,
+		},
+		{
+			Name:             "Client ID App",
+			ClientID:         "Iv1.ListFormat",
+			InstallationID:   456,
+			Patterns:         []string{"github.com/client-org/*"},
+			Priority:         10,
 			PrivateKeySource: config.PrivateKeySourceKeyring,
 		},
 	}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -189,7 +189,7 @@ func displayMigrationSummary(
 	if len(appsNeedAttention) > 0 {
 		fmt.Printf("⚠️  Apps needing attention (inline keys):\n")
 		for _, app := range appsNeedAttention {
-			fmt.Printf("  • %s (ID: %d) - inline key detected\n", app.Name, app.AppID)
+			fmt.Printf("  • %s (ID: %s) - inline key detected\n", app.Name, app.GetIdentifier())
 		}
 		fmt.Printf("\n")
 	}
@@ -202,7 +202,7 @@ func displayMigrationSummary(
 			if currentSource == "" {
 				currentSource = "legacy"
 			}
-			fmt.Printf("  • %s (ID: %d)\n", app.Name, app.AppID)
+			fmt.Printf("  • %s (ID: %s)\n", app.Name, app.GetIdentifier())
 			fmt.Printf("    From: %s → To: %s\n", currentSource, storage)
 		}
 		fmt.Printf("\n")
@@ -244,7 +244,7 @@ func performMigration(
 			continue
 		}
 
-		fmt.Printf("  Migrating '%s' (ID: %d)...\n", app.Name, app.AppID)
+		fmt.Printf("  Migrating '%s' (ID: %s)...\n", app.Name, app.GetIdentifier())
 
 		// Get current private key
 		privateKey, err := app.GetPrivateKey(secretMgr)

--- a/cmd/migrate_run_test.go
+++ b/cmd/migrate_run_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
+	"github.com/AmadeusITGroup/gh-app-auth/pkg/secrets"
 	"gopkg.in/yaml.v3"
 )
 
@@ -261,4 +262,69 @@ func TestDisplayMigrationSummary_Direct(t *testing.T) {
 			t.Error("Expected to exit when no migrations needed")
 		}
 	})
+
+	t.Run("display summary with apps needing attention", func(t *testing.T) {
+		attention := []config.GitHubApp{
+			{Name: "Inline App", AppID: 345678, ClientID: "Iv1.Attention"},
+		}
+
+		shouldExit := displayMigrationSummary(
+			apps, []config.GitHubApp{}, appsUpToDate, attention,
+			"keyring", false,
+		)
+
+		// The function only exits early when there is nothing to do;
+		// attention-only flows continue to displayMigrationResults.
+		if shouldExit {
+			t.Error("Expected not to exit when only attention is needed")
+		}
+	})
+
+	t.Run("display summary with migrations to perform", func(t *testing.T) {
+		toMigrate := []config.GitHubApp{apps[0]}
+
+		shouldExit := displayMigrationSummary(
+			apps, toMigrate, []config.GitHubApp{}, []config.GitHubApp{},
+			"keyring", false,
+		)
+
+		if shouldExit {
+			t.Error("Expected to continue when migrations are scheduled")
+		}
+	})
+}
+
+func TestPerformMigration(t *testing.T) {
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "test-key.pem")
+	testKey := generateTestRSAKey(t)
+	if err := os.WriteFile(keyPath, []byte(testKey), 0600); err != nil {
+		t.Fatalf("Failed to write test key: %v", err)
+	}
+
+	cfg := &config.Config{
+		Version: "1.0",
+		GitHubApps: []config.GitHubApp{
+			{
+				Name:             "Migrate App",
+				AppID:            123456,
+				ClientID:         "Iv1.Migrate",
+				InstallationID:   789012,
+				Patterns:         []string{"github.com/org/*"},
+				PrivateKeySource: config.PrivateKeySourceFilesystem,
+				PrivateKeyPath:   keyPath,
+			},
+		},
+	}
+
+	appsToMigrate := []config.GitHubApp{cfg.GitHubApps[0]}
+	secretMgr := secrets.NewManager(tempDir)
+
+	migrated, failed := performMigration(cfg, appsToMigrate, secretMgr, "filesystem", false)
+	if failed != 0 {
+		t.Errorf("performMigration() failed = %d, want 0", failed)
+	}
+	if migrated != 1 {
+		t.Errorf("performMigration() migrated = %d, want 1", migrated)
+	}
 }

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -19,11 +19,12 @@ const (
 
 func NewRemoveCmd() *cobra.Command {
 	var (
-		appID   int64
-		patName string
-		force   bool
-		allApps bool
-		allPATs bool
+		appID    int64
+		clientID string
+		patName  string
+		force    bool
+		allApps  bool
+		allPATs  bool
 	)
 
 	cmd := &cobra.Command{
@@ -33,12 +34,15 @@ func NewRemoveCmd() *cobra.Command {
 
 	This will remove the credential configuration and clear any cached secrets.`,
 		Aliases: []string{"rm", "delete"},
-		Example: `  # Remove specific app
+		Example: `  # Remove specific app by numeric App ID
   gh app-auth remove --app-id 123456
-  
+
+  # Remove specific app by Client ID
+  gh app-auth remove --client-id Iv1.AbCdEfGhIjKlMn
+
   # Remove without confirmation
-  gh app-auth remove --app-id 123456 --force
-  
+  gh app-auth remove --client-id Iv1.AbCdEfGhIjKlMn --force
+
   # Remove all configured apps
   gh app-auth remove --all
 
@@ -47,10 +51,11 @@ func NewRemoveCmd() *cobra.Command {
 
   # Remove all Personal Access Tokens
   gh app-auth remove --all-pats`,
-		RunE: removeRun(&appID, &patName, &force, &allApps, &allPATs),
+		RunE: removeRun(&appID, &clientID, &patName, &force, &allApps, &allPATs),
 	}
 
 	cmd.Flags().Int64Var(&appID, "app-id", 0, "GitHub App ID to remove")
+	cmd.Flags().StringVar(&clientID, "client-id", "", "GitHub App Client ID to remove")
 	cmd.Flags().StringVar(&patName, "pat-name", "", "Personal Access Token name to remove")
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVar(&allApps, "all", false, "Remove all configured GitHub Apps")
@@ -59,13 +64,20 @@ func NewRemoveCmd() *cobra.Command {
 	return cmd
 }
 
-func removeRun(appID *int64, patName *string, force, allApps, allPATs *bool) func(*cobra.Command, []string) error {
+func removeRun(
+	appID *int64,
+	clientID, patName *string,
+	force, allApps, allPATs *bool,
+) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		targetCount := 0
 		if *allApps {
 			targetCount++
 		}
 		if *appID > 0 {
+			targetCount++
+		}
+		if *clientID != "" {
 			targetCount++
 		}
 		if *patName != "" {
@@ -76,11 +88,11 @@ func removeRun(appID *int64, patName *string, force, allApps, allPATs *bool) fun
 		}
 
 		if targetCount == 0 {
-			return fmt.Errorf("specify one of --app-id, --pat-name, --all, or --all-pats")
+			return fmt.Errorf("specify one of --app-id, --client-id, --pat-name, --all, or --all-pats")
 		}
 
 		if targetCount > 1 {
-			return fmt.Errorf("use only one of --app-id, --pat-name, --all, or --all-pats at a time")
+			return fmt.Errorf("use only one of --app-id, --client-id, --pat-name, --all, or --all-pats at a time")
 		}
 
 		// Load configuration
@@ -108,12 +120,12 @@ func removeRun(appID *int64, patName *string, force, allApps, allPATs *bool) fun
 			return removeAllApps(cfg, *force)
 		}
 
-		if *appID > 0 {
+		if *appID > 0 || *clientID != "" {
 			if !hasApps {
 				fmt.Printf("No GitHub Apps configured.\n")
 				return nil
 			}
-			return removeSingleApp(cfg, *appID, *force)
+			return removeSingleApp(cfg, *appID, *clientID, *force)
 		}
 
 		if *allPATs {
@@ -133,9 +145,9 @@ func removeRun(appID *int64, patName *string, force, allApps, allPATs *bool) fun
 	}
 }
 
-func removeSingleApp(cfg *config.Config, appID int64, force bool) error {
+func removeSingleApp(cfg *config.Config, appID int64, clientID string, force bool) error {
 	// Find the app
-	appIndex, appToRemove, err := findAppByID(cfg, appID)
+	appIndex, appToRemove, err := findApp(cfg, appID, clientID)
 	if err != nil {
 		return err
 	}
@@ -148,7 +160,7 @@ func removeSingleApp(cfg *config.Config, appID int64, force bool) error {
 	}
 
 	// Perform the removal
-	return performAppRemoval(cfg, appIndex, appToRemove, appID)
+	return performAppRemoval(cfg, appIndex, appToRemove)
 }
 
 func removeAllApps(cfg *config.Config, force bool) error {
@@ -202,7 +214,7 @@ func removeAllPATs(cfg *config.Config, force bool) error {
 	return nil
 }
 
-func clearCachedTokens(appID int64) error {
+func clearCachedTokens(identifier string) error {
 	// Implementation would clear cached tokens for specific app
 	// For now, just a placeholder
 	return nil
@@ -214,12 +226,18 @@ func clearAllCachedTokens() error {
 	return nil
 }
 
-// findAppByID finds an app by ID and returns its index and the app itself
-func findAppByID(cfg *config.Config, appID int64) (int, config.GitHubApp, error) {
+// findApp finds an app by numeric App ID or Client ID and returns its index and the app itself
+func findApp(cfg *config.Config, appID int64, clientID string) (int, config.GitHubApp, error) {
 	for i, app := range cfg.GitHubApps {
-		if app.AppID == appID {
+		if clientID != "" && app.ClientID == clientID {
 			return i, app, nil
 		}
+		if appID > 0 && app.AppID == appID {
+			return i, app, nil
+		}
+	}
+	if clientID != "" {
+		return -1, config.GitHubApp{}, fmt.Errorf("GitHub App with client ID %s not found", clientID)
 	}
 	return -1, config.GitHubApp{}, fmt.Errorf("GitHub App with ID %d not found", appID)
 }
@@ -228,7 +246,7 @@ func findAppByID(cfg *config.Config, appID int64) (int, config.GitHubApp, error)
 func confirmAppRemoval(appToRemove config.GitHubApp) bool {
 	fmt.Printf("This will remove the following GitHub App configuration:\n")
 	fmt.Printf("  Name: %s\n", appToRemove.Name)
-	fmt.Printf("  App ID: %d\n", appToRemove.AppID)
+	fmt.Printf("  App ID: %s\n", appToRemove.GetIdentifier())
 	fmt.Printf("  Patterns: %v\n", appToRemove.Patterns)
 	fmt.Printf("\nAre you sure? (y/N): ")
 
@@ -243,7 +261,7 @@ func confirmAppRemoval(appToRemove config.GitHubApp) bool {
 }
 
 // performAppRemoval performs the actual app removal operations
-func performAppRemoval(cfg *config.Config, appIndex int, appToRemove config.GitHubApp, appID int64) error {
+func performAppRemoval(cfg *config.Config, appIndex int, appToRemove config.GitHubApp) error {
 	// Initialize secrets manager
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -266,11 +284,11 @@ func performAppRemoval(cfg *config.Config, appIndex int, appToRemove config.GitH
 	}
 
 	// Clear cached tokens for this app
-	if err := clearCachedTokens(appID); err != nil {
+	if err := clearCachedTokens(appToRemove.GetIdentifier()); err != nil {
 		fmt.Printf("⚠️  Warning: failed to clear cached tokens: %v\n", err)
 	}
 
-	fmt.Printf("✅ Successfully removed GitHub App '%s' (ID: %d)\n", appToRemove.Name, appID)
+	fmt.Printf("✅ Successfully removed GitHub App '%s' (ID: %s)\n", appToRemove.Name, appToRemove.GetIdentifier())
 	fmt.Printf("   🗑️  Private key deleted from secure storage\n")
 	return nil
 }
@@ -279,7 +297,7 @@ func performAppRemoval(cfg *config.Config, appIndex int, appToRemove config.GitH
 func confirmAllAppsRemoval(apps []config.GitHubApp) bool {
 	fmt.Printf("This will remove ALL %d configured GitHub Apps:\n", len(apps))
 	for _, app := range apps {
-		fmt.Printf("  - %s (ID: %d)\n", app.Name, app.AppID)
+		fmt.Printf("  - %s (ID: %s)\n", app.Name, app.GetIdentifier())
 	}
 	fmt.Printf("\nAre you sure? (y/N): ")
 

--- a/cmd/remove_run_test.go
+++ b/cmd/remove_run_test.go
@@ -322,3 +322,14 @@ func TestRemoveRun_RemoveByClientID(t *testing.T) {
 		}
 	})
 }
+
+func TestRemoveRun_ConflictingFlagsWithClientID(t *testing.T) {
+	cmd := NewRemoveCmd()
+	cmd.Flags().Set("client-id", "Iv1.Conflict")
+	cmd.Flags().Set("all", "true")
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("Expected error for conflicting flags")
+	}
+}

--- a/cmd/remove_run_test.go
+++ b/cmd/remove_run_test.go
@@ -248,3 +248,77 @@ func TestRemoveRun_RemoveAllApps(t *testing.T) {
 		}
 	})
 }
+
+func TestRemoveRun_RemoveByClientID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yml")
+	keyPath := filepath.Join(tempDir, "test-key.pem")
+
+	// Generate valid test key
+	testKey := generateTestRSAKey(t)
+	if err := os.WriteFile(keyPath, []byte(testKey), 0600); err != nil {
+		t.Fatalf("Failed to write test key: %v", err)
+	}
+
+	cfg := &config.Config{
+		Version: "1.0",
+		GitHubApps: []config.GitHubApp{
+			{
+				Name:             "Client ID App",
+				ClientID:         "Iv1.ClientApp123",
+				InstallationID:   789012,
+				Patterns:         []string{"github.com/client-org/*"},
+				Priority:         10,
+				PrivateKeySource: config.PrivateKeySourceFilesystem,
+				PrivateKeyPath:   keyPath,
+			},
+			{
+				Name:             "Numeric App",
+				AppID:            123456,
+				InstallationID:   890123,
+				Patterns:         []string{"github.com/org/*"},
+				Priority:         5,
+				PrivateKeySource: config.PrivateKeySourceFilesystem,
+				PrivateKeyPath:   keyPath,
+			},
+		},
+	}
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Failed to marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, data, 0600); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	t.Setenv("GH_APP_AUTH_CONFIG", configPath)
+
+	t.Run("remove by client id with force", func(t *testing.T) {
+		cmd := NewRemoveCmd()
+		cmd.Flags().Set("client-id", "Iv1.ClientApp123")
+		cmd.Flags().Set("force", "true")
+
+		err := cmd.Execute()
+		if err != nil {
+			t.Errorf("Remove command failed: %v", err)
+		}
+
+		updatedCfg, err := config.Load()
+		if err != nil {
+			t.Fatalf("Failed to load updated config: %v", err)
+		}
+
+		if len(updatedCfg.GitHubApps) != 1 {
+			t.Errorf("Expected 1 app remaining, got %d", len(updatedCfg.GitHubApps))
+		}
+
+		if len(updatedCfg.GitHubApps) > 0 && updatedCfg.GitHubApps[0].ClientID != "" {
+			t.Error("Client ID app should have been removed")
+		}
+	})
+}

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -136,3 +136,18 @@ func TestConfirmAllAppsRemoval(t *testing.T) {
 	// Skip interactive test - would need stdin mocking
 	t.Skip("Interactive function - requires stdin mocking")
 }
+
+func TestRemoveSingleApp_ClientIDNotFound(t *testing.T) {
+	cfg := &config.Config{
+		Version: "1.0",
+		GitHubApps: []config.GitHubApp{
+			{Name: "App1", AppID: 111111},
+			{Name: "App2", AppID: 222222, ClientID: "Iv1.ClientTwo"},
+		},
+	}
+
+	err := removeSingleApp(cfg, 0, "Iv1.NotFound", true)
+	if err == nil {
+		t.Error("Expected error when removing app by non-existent client ID")
+	}
+}

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -6,12 +6,12 @@ import (
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
 )
 
-func TestFindAppByID(t *testing.T) {
+func TestFindApp(t *testing.T) {
 	cfg := &config.Config{
 		Version: "1.0",
 		GitHubApps: []config.GitHubApp{
 			{Name: "App1", AppID: 111111},
-			{Name: "App2", AppID: 222222},
+			{Name: "App2", AppID: 222222, ClientID: "Iv1.ClientTwo"},
 			{Name: "App3", AppID: 333333},
 		},
 	}
@@ -19,20 +19,28 @@ func TestFindAppByID(t *testing.T) {
 	tests := []struct {
 		name      string
 		appID     int64
+		clientID  string
 		wantIndex int
 		wantName  string
 		wantErr   bool
 	}{
 		{
-			name:      "find first app",
+			name:      "find first app by id",
 			appID:     111111,
 			wantIndex: 0,
 			wantName:  "App1",
 			wantErr:   false,
 		},
 		{
-			name:      "find middle app",
+			name:      "find middle app by id",
 			appID:     222222,
+			wantIndex: 1,
+			wantName:  "App2",
+			wantErr:   false,
+		},
+		{
+			name:      "find middle app by client id",
+			clientID:  "Iv1.ClientTwo",
 			wantIndex: 1,
 			wantName:  "App2",
 			wantErr:   false,
@@ -45,8 +53,14 @@ func TestFindAppByID(t *testing.T) {
 			wantErr:   false,
 		},
 		{
-			name:      "app not found",
+			name:      "app not found by id",
 			appID:     999999,
+			wantIndex: -1,
+			wantErr:   true,
+		},
+		{
+			name:      "app not found by client id",
+			clientID:  "Iv1.NotFound",
 			wantIndex: -1,
 			wantErr:   true,
 		},
@@ -54,7 +68,7 @@ func TestFindAppByID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			index, app, err := findAppByID(cfg, tt.appID)
+			index, app, err := findApp(cfg, tt.appID, tt.clientID)
 
 			if tt.wantErr {
 				if err == nil {
@@ -79,7 +93,11 @@ func TestFindAppByID(t *testing.T) {
 				t.Errorf("Name = %q, want %q", app.Name, tt.wantName)
 			}
 
-			if app.AppID != tt.appID {
+			if tt.clientID != "" {
+				if app.ClientID != tt.clientID {
+					t.Errorf("ClientID = %q, want %q", app.ClientID, tt.clientID)
+				}
+			} else if app.AppID != tt.appID {
 				t.Errorf("AppID = %d, want %d", app.AppID, tt.appID)
 			}
 		})
@@ -88,7 +106,7 @@ func TestFindAppByID(t *testing.T) {
 
 func TestClearCachedTokens(t *testing.T) {
 	// Test placeholder implementation
-	err := clearCachedTokens(123456)
+	err := clearCachedTokens("123456")
 	if err != nil {
 		t.Errorf("clearCachedTokens() error = %v", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,7 @@ func init() {
 	rootCmd.AddCommand(NewListCmd())
 	rootCmd.AddCommand(NewRemoveCmd())
 	rootCmd.AddCommand(NewTestCmd())
+	rootCmd.AddCommand(NewExecCmd())
 	rootCmd.AddCommand(NewGitCredentialCmd())
 	rootCmd.AddCommand(NewGitConfigCmd())
 	rootCmd.AddCommand(NewMigrateCmd())

--- a/cmd/scope.go
+++ b/cmd/scope.go
@@ -71,7 +71,7 @@ func scopeRun(forceRefresh bool) error {
 		needsRefresh := forceRefresh || scopeMgr.NeedsRefresh(app)
 
 		if needsRefresh {
-			fmt.Printf("Fetching scope for %q (App ID: %d)...\n", app.Name, app.AppID)
+			fmt.Printf("Fetching scope for %q (App ID: %s)...\n", app.Name, app.GetIdentifier())
 
 			// Get private key
 			privateKey, err := app.GetPrivateKey(secretsMgr)
@@ -81,7 +81,7 @@ func scopeRun(forceRefresh bool) error {
 			}
 
 			// Generate JWT
-			jwtToken, err := jwtGen.GenerateTokenFromKey(app.AppID, privateKey)
+			jwtToken, err := jwtGen.GenerateTokenFromKey(app.GetIssuer(), privateKey)
 			if err != nil {
 				fmt.Printf("  ⚠️  Failed to generate JWT: %v\n", err)
 				continue
@@ -112,7 +112,7 @@ func scopeRun(forceRefresh bool) error {
 }
 
 func displayScope(app *config.GitHubApp) {
-	fmt.Printf("\n📦 %s (App ID: %d, Installation ID: %d)\n", app.Name, app.AppID, app.InstallationID)
+	fmt.Printf("\n📦 %s (App ID: %s, Installation ID: %d)\n", app.Name, app.GetIdentifier(), app.InstallationID)
 
 	if app.Scope == nil {
 		fmt.Println("   ⚠️  No scope information cached")

--- a/cmd/scope_test.go
+++ b/cmd/scope_test.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
+	"gopkg.in/yaml.v3"
 )
 
 func TestDisplayScope(t *testing.T) {
@@ -96,6 +99,24 @@ func TestDisplayScope(t *testing.T) {
 		// Should not panic
 		displayScope(app)
 	})
+
+	t.Run("client id app", func(t *testing.T) {
+		app := &config.GitHubApp{
+			Name:           "Client ID App",
+			ClientID:       "Iv1.ScopeDisplay",
+			InstallationID: 456,
+			Scope: &config.InstallationScope{
+				RepositorySelection: "all",
+				AccountLogin:        "testorg",
+				AccountType:         "Organization",
+				LastFetched:         time.Now(),
+				CacheExpiry:         time.Now().Add(24 * time.Hour),
+			},
+		}
+
+		// Should not panic
+		displayScope(app)
+	})
 }
 
 func TestNewScopeCmd(t *testing.T) {
@@ -168,5 +189,39 @@ func TestScopeCmd_FlagValidation(t *testing.T) {
 				t.Errorf("ParseFlags() error = %v, want success = %v", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestScopeRun_RefreshWithClientID(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yml")
+
+	cfg := &config.Config{
+		Version: "1.0",
+		GitHubApps: []config.GitHubApp{
+			{
+				Name:             "Scoped App",
+				ClientID:         "Iv1.ScopeApp",
+				InstallationID:   789012,
+				Patterns:         []string{"github.com/org/*"},
+				PrivateKeySource: config.PrivateKeySourceFilesystem,
+				PrivateKeyPath:   "/nonexistent/key.pem",
+			},
+		},
+	}
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Failed to marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, data, 0600); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	t.Setenv("GH_APP_AUTH_CONFIG", configPath)
+
+	err = scopeRun(true)
+	if err != nil {
+		t.Errorf("scopeRun() error = %v", err)
 	}
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -93,6 +93,7 @@ func validateMultiPatternSetup(patterns []string) error {
 func NewSetupCmd() *cobra.Command {
 	var (
 		appID          int64
+		clientID       string
 		keyFile        string
 		patterns       []string
 		name           string
@@ -110,21 +111,24 @@ func NewSetupCmd() *cobra.Command {
 		Long: `Configure GitHub App authentication for specific repository patterns.
 
 This command sets up a GitHub App for authentication with git operations.
-You'll need the App ID and private key file from your GitHub App settings.`,
-		Example: `  # Basic setup
+You'll need the App ID or Client ID and private key file from your GitHub App settings.`,
+		Example: `  # Basic setup with numeric App ID
   gh app-auth setup --app-id 123456 --key-file ~/.ssh/my-app.pem --patterns "github.com/myorg/*"
-  
+
+  # Basic setup with Client ID (preferred)
+  gh app-auth setup --client-id Iv1.AbCdEfGhIjKlMn --key-file ~/.ssh/my-app.pem --patterns "github.com/myorg/*"
+
   # Setup with custom name and priority
   gh app-auth setup \
-    --app-id 123456 \
+    --client-id Iv1.AbCdEfGhIjKlMn \
     --key-file ~/.ssh/my-app.pem \
     --patterns "github.com/myorg/*" \
     --name "Corporate App" \
     --priority 10
-    
+
   # Multiple patterns
   gh app-auth setup \
-    --app-id 123456 \
+    --client-id Iv1.AbCdEfGhIjKlMn \
     --key-file ~/.ssh/my-app.pem \
     --patterns "github.com/myorg/*,github.example.com/corp/*"
 
@@ -143,13 +147,14 @@ You'll need the App ID and private key file from your GitHub App settings.`,
     --name "Bitbucket PAT" \
     --priority 10`,
 		RunE: setupRun(
-			&appID, &keyFile, &patterns, &name, &installationID,
+			&appID, &clientID, &keyFile, &patterns, &name, &installationID,
 			&priority, &useKeyring, &useFilesystem, &pat, &username,
 		),
 	}
 
 	// GitHub App flags
-	cmd.Flags().Int64Var(&appID, "app-id", 0, "GitHub App ID (required for app setup)")
+	cmd.Flags().Int64Var(&appID, "app-id", 0, "GitHub App ID (legacy; optional if --client-id is provided)")
+	cmd.Flags().StringVar(&clientID, "client-id", "", "GitHub App Client ID (preferred; optional if --app-id is provided)")
 	cmd.Flags().StringVar(&keyFile, "key-file", "", "Path to private key file (or use GH_APP_PRIVATE_KEY env var)")
 	cmd.Flags().Int64Var(&installationID, "installation-id", 0, "Installation ID (auto-detected if not provided)")
 
@@ -177,21 +182,21 @@ You'll need the App ID and private key file from your GitHub App settings.`,
 }
 
 func setupRun(
-	appID *int64, keyFile *string, patterns *[]string,
+	appID *int64, clientID *string, keyFile *string, patterns *[]string,
 	name *string, installationID *int64, priority *int,
 	useKeyring *bool, useFilesystem *bool, pat *string, username *string,
 ) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		// Determine if this is PAT or App setup
 		isPATSetup := *pat != ""
-		isAppSetup := *appID > 0
+		isAppSetup := *appID > 0 || *clientID != ""
 
 		// Validate mutually exclusive options
 		if isPATSetup && isAppSetup {
-			return fmt.Errorf("cannot use both --pat and --app-id; choose one authentication method")
+			return fmt.Errorf("cannot use both --pat and --app-id/--client-id; choose one authentication method")
 		}
 		if !isPATSetup && !isAppSetup {
-			return fmt.Errorf("must specify either --pat for PAT setup or --app-id for GitHub App setup")
+			return fmt.Errorf("must specify either --pat for PAT setup or --app-id/--client-id for GitHub App setup")
 		}
 
 		// Load or create configuration
@@ -206,7 +211,7 @@ func setupRun(
 		}
 
 		_, err = setupGitHubApp(
-			cfg, *appID, *keyFile, *name, *installationID,
+			cfg, *appID, *clientID, *keyFile, *name, *installationID,
 			*patterns, *priority, *useKeyring, *useFilesystem, false,
 		)
 		return err
@@ -214,11 +219,11 @@ func setupRun(
 }
 
 func setupGitHubApp(
-	cfg *config.Config, appID int64, keyFile, name string, installationID int64,
+	cfg *config.Config, appID int64, clientID, keyFile, name string, installationID int64,
 	patterns []string, priority int, useKeyring, useFilesystem bool, silent bool,
 ) (*config.GitHubApp, error) {
 	// Validate inputs
-	if err := validateSetupInputs(appID, patterns, &useKeyring, &useFilesystem, keyFile); err != nil {
+	if err := validateSetupInputs(appID, clientID, patterns, &useKeyring, &useFilesystem, keyFile); err != nil {
 		return nil, err
 	}
 
@@ -228,8 +233,11 @@ func setupGitHubApp(
 		return nil, err
 	}
 
+	// Determine the JWT issuer for this app
+	issuer := setupIssuer(appID, clientID)
+
 	// Test JWT generation to ensure key is valid
-	jwtToken, err := generateJWTForSetup(appID, privateKeyContent)
+	jwtToken, err := generateJWTForSetup(issuer, privateKeyContent)
 	if err != nil {
 		return nil, err
 	}
@@ -259,7 +267,7 @@ func setupGitHubApp(
 		}
 
 		// Create the GitHub App entry for this org
-		app := createGitHubApp(appID, name, orgInstallationID, orgPatterns, priority)
+		app := createGitHubApp(appID, clientID, name, orgInstallationID, orgPatterns, priority)
 
 		// Store private key and configure storage (only needed once, but we do it for each)
 		backend, err = configureAppStorage(&app, privateKeyContent, expandedKeyFile, useKeyring)
@@ -284,11 +292,12 @@ func setupGitHubApp(
 	}
 
 	// Display success message and next steps
-	if !silent {
+	if !silent && firstApp != nil {
+		identifier := firstApp.GetIdentifier()
 		if len(groupedPatterns) > 1 {
-			displaySetupSuccessMultiOrg(name, appID, groupedPatterns, priority, backend, expandedKeyFile)
+			displaySetupSuccessMultiOrg(firstApp.Name, identifier, groupedPatterns, priority, backend, expandedKeyFile)
 		} else {
-			displaySetupSuccess(name, appID, patterns, priority, backend, expandedKeyFile)
+			displaySetupSuccess(firstApp.Name, identifier, patterns, priority, backend, expandedKeyFile)
 		}
 	}
 
@@ -383,10 +392,29 @@ func validateKeyFile(keyPath string) error {
 	return nil
 }
 
+// setupIssuer returns the appropriate JWT issuer for the provided app/client ID pair.
+func setupIssuer(appID int64, clientID string) any {
+	if clientID != "" {
+		return clientID
+	}
+	return appID
+}
+
 // validateSetupInputs validates the setup command inputs
-func validateSetupInputs(appID int64, patterns []string, useKeyring *bool, useFilesystem *bool, keyFile string) error {
-	if appID <= 0 {
+func validateSetupInputs(
+	appID int64,
+	clientID string,
+	patterns []string,
+	useKeyring *bool,
+	useFilesystem *bool,
+	keyFile string,
+) error {
+	if appID < 0 {
 		return fmt.Errorf("app-id must be a positive integer")
+	}
+
+	if appID == 0 && clientID == "" {
+		return fmt.Errorf("app-id or client-id is required")
 	}
 
 	if len(patterns) == 0 {
@@ -440,9 +468,9 @@ func getPrivateKey(keyFile string) (string, string, error) {
 }
 
 // generateJWTForSetup generates a JWT token and returns it for use in setup
-func generateJWTForSetup(appID int64, privateKeyContent string) (string, error) {
+func generateJWTForSetup(issuer any, privateKeyContent string) (string, error) {
 	generator := jwt.NewGenerator()
-	token, err := generator.GenerateTokenFromKey(appID, privateKeyContent)
+	token, err := generator.GenerateTokenFromKey(issuer, privateKeyContent)
 	if err != nil {
 		return "", fmt.Errorf("JWT generation test failed: %w", err)
 	}
@@ -563,17 +591,22 @@ func findInstallationForOrg(jwtToken, host, org string) (int64, error) {
 // createGitHubApp creates a GitHub App configuration
 // Note: Validation is done later after storage configuration is complete
 func createGitHubApp(
-	appID int64, name string, installationID int64, patterns []string, priority int,
+	appID int64, clientID, name string, installationID int64, patterns []string, priority int,
 ) config.GitHubApp {
 	// Set default name if not provided
 	if name == "" {
-		name = fmt.Sprintf("GitHub App %d", appID)
+		if clientID != "" {
+			name = fmt.Sprintf("GitHub App %s", clientID)
+		} else {
+			name = fmt.Sprintf("GitHub App %d", appID)
+		}
 	}
 
 	// Create GitHub App configuration
 	return config.GitHubApp{
 		Name:           name,
 		AppID:          appID,
+		ClientID:       clientID,
 		InstallationID: installationID,
 		Patterns:       patterns,
 		Priority:       priority,
@@ -628,11 +661,11 @@ func saveAppConfiguration(cfg *config.Config, app *config.GitHubApp) error {
 
 // displaySetupSuccess displays the success message and next steps
 func displaySetupSuccess(
-	name string, appID int64, patterns []string, priority int,
+	name, identifier string, patterns []string, priority int,
 	backend secrets.StorageBackend, expandedKeyFile string,
 ) {
 	fmt.Printf("✅ Successfully configured GitHub App '%s'\n", name)
-	fmt.Printf("   App ID: %d\n", appID)
+	fmt.Printf("   App ID: %s\n", identifier)
 	fmt.Printf("   Patterns: %s\n", strings.Join(patterns, ", "))
 	fmt.Printf("   Priority: %d\n", priority)
 
@@ -656,11 +689,11 @@ func displaySetupSuccess(
 
 // displaySetupSuccessMultiOrg displays success message for multi-org setup
 func displaySetupSuccessMultiOrg(
-	name string, appID int64, groupedPatterns map[string][]string, priority int,
+	name, identifier string, groupedPatterns map[string][]string, priority int,
 	backend secrets.StorageBackend, expandedKeyFile string,
 ) {
 	fmt.Printf("✅ Successfully configured GitHub App '%s'\n", name)
-	fmt.Printf("   App ID: %d\n", appID)
+	fmt.Printf("   App ID: %s\n", identifier)
 	fmt.Printf("   Organizations configured: %d\n", len(groupedPatterns))
 
 	// Display each organization and its patterns

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -384,12 +385,20 @@ func validateKeyFile(keyPath string) error {
 	}
 
 	// Check permissions (should be 600 or 400)
-	if fileInfo.Mode().Perm()&0044 != 0 {
-		return fmt.Errorf("private key file has overly permissive permissions %o (should be 600 or 400)",
-			fileInfo.Mode().Perm())
+	// Skip this check on Windows where file permissions work differently
+	if !isWindows() {
+		if fileInfo.Mode().Perm()&0044 != 0 {
+			return fmt.Errorf("private key file has overly permissive permissions %o (should be 600 or 400)",
+				fileInfo.Mode().Perm())
+		}
 	}
 
 	return nil
+}
+
+// isWindows returns true if the current OS is Windows.
+func isWindows() bool {
+	return runtime.GOOS == "windows"
 }
 
 // setupIssuer returns the appropriate JWT issuer for the provided app/client ID pair.

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -1094,3 +1094,113 @@ func TestDisplaySetupSuccess(t *testing.T) {
 		})
 	}
 }
+
+func TestSetupIssuer(t *testing.T) {
+	tests := []struct {
+		name     string
+		appID    int64
+		clientID string
+		want     any
+	}{
+		{
+			name:     "client id preferred",
+			clientID: "Iv1.AbCdEfGhIjKlMn",
+			want:     "Iv1.AbCdEfGhIjKlMn",
+		},
+		{
+			name:  "app id fallback",
+			appID: 123456,
+			want:  int64(123456),
+		},
+		{
+			name:     "both prefers client id",
+			appID:    123456,
+			clientID: "Iv1.Preferred",
+			want:     "Iv1.Preferred",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := setupIssuer(tt.appID, tt.clientID)
+			if got != tt.want {
+				t.Errorf("setupIssuer() = %v (%T), want %v (%T)", got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetupRun_WithClientID(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yml")
+	keyPath := filepath.Join(tempDir, "test-key.pem")
+
+	testKey := generateTestRSAKey(t)
+	if err := os.WriteFile(keyPath, []byte(testKey), 0600); err != nil {
+		t.Fatalf("Failed to write test key: %v", err)
+	}
+
+	t.Setenv("GH_APP_AUTH_CONFIG", configPath)
+
+	cmd := NewSetupCmd()
+	cmd.Flags().Set("client-id", "Iv1.RunSetup")
+	cmd.Flags().Set("key-file", keyPath)
+	cmd.Flags().Set("patterns", "github.com/org/*")
+	cmd.Flags().Set("installation-id", "789012")
+	cmd.Flags().Set("use-filesystem", "true")
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Errorf("setupRun() with client ID error = %v", err)
+	}
+}
+
+func TestSetupGitHubApp(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yml")
+	keyPath := filepath.Join(tempDir, "test-key.pem")
+
+	testKey := generateTestRSAKey(t)
+	if err := os.WriteFile(keyPath, []byte(testKey), 0600); err != nil {
+		t.Fatalf("Failed to write test key: %v", err)
+	}
+
+	t.Setenv("GH_APP_AUTH_CONFIG", configPath)
+
+	t.Run("client id with provided installation id", func(t *testing.T) {
+		cfg := &config.Config{Version: "1.0"}
+		app, err := setupGitHubApp(
+			cfg, 0, "Iv1.AbCdEfGhIjKlMn", keyPath, "Client ID App", 789012,
+			[]string{"github.com/org/*"}, 5, false, true, false,
+		)
+		if err != nil {
+			t.Fatalf("setupGitHubApp() error = %v", err)
+		}
+		if app == nil {
+			t.Fatal("setupGitHubApp() returned nil app")
+		}
+		if app.ClientID != "Iv1.AbCdEfGhIjKlMn" {
+			t.Errorf("ClientID = %q, want %q", app.ClientID, "Iv1.AbCdEfGhIjKlMn")
+		}
+		if app.InstallationID != 789012 {
+			t.Errorf("InstallationID = %d, want %d", app.InstallationID, 789012)
+		}
+	})
+
+	t.Run("client id with multiple orgs", func(t *testing.T) {
+		cfg := &config.Config{Version: "1.0"}
+		app, err := setupGitHubApp(
+			cfg, 0, "Iv1.MultiOrg", keyPath, "Multi Org App", 789012,
+			[]string{"github.com/org1/*", "github.com/org2/*"}, 5, false, true, false,
+		)
+		if err != nil {
+			t.Fatalf("setupGitHubApp() error = %v", err)
+		}
+		if app == nil {
+			t.Fatal("setupGitHubApp() returned nil app")
+		}
+		if app.ClientID != "Iv1.MultiOrg" {
+			t.Errorf("ClientID = %q, want %q", app.ClientID, "Iv1.MultiOrg")
+		}
+	})
+}

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -202,7 +201,7 @@ func TestGetPrivateKey(t *testing.T) {
 
 	t.Run("from file", func(t *testing.T) {
 		// Skip on Windows - file permissions are not enforced the same way
-		if runtime.GOOS == "windows" {
+		if isWindows() {
 			t.Skip("Skipping on Windows: file permissions not supported")
 		}
 
@@ -250,7 +249,7 @@ func TestGetPrivateKey(t *testing.T) {
 
 func TestValidateKeyFile(t *testing.T) {
 	// Skip on Windows - file permissions are not enforced the same way
-	if runtime.GOOS == "windows" {
+	if isWindows() {
 		t.Skip("Skipping on Windows: file permissions not supported")
 	}
 

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
+	"github.com/AmadeusITGroup/gh-app-auth/pkg/jwt"
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/secrets"
 )
 
@@ -62,6 +64,7 @@ func TestValidateSetupInputs(t *testing.T) {
 	tests := []struct {
 		name           string
 		appID          int64
+		clientID       string
 		patterns       []string
 		useKeyring     bool
 		useFilesystem  bool
@@ -74,6 +77,15 @@ func TestValidateSetupInputs(t *testing.T) {
 		{
 			name:        "valid inputs with keyring",
 			appID:       123456,
+			patterns:    []string{"github.com/org/*"},
+			useKeyring:  true,
+			keyFile:     "",
+			wantErr:     false,
+			wantKeyring: true,
+		},
+		{
+			name:        "valid inputs with client id",
+			clientID:    "Iv1.AbCdEfGhIjKlMn",
 			patterns:    []string{"github.com/org/*"},
 			useKeyring:  true,
 			keyFile:     "",
@@ -103,7 +115,7 @@ func TestValidateSetupInputs(t *testing.T) {
 			expectedErr:    ErrConflictingKeyOptions,
 		},
 		{
-			name:     "invalid app ID - zero",
+			name:     "invalid app ID - zero without client id",
 			appID:    0,
 			patterns: []string{"github.com/org/*"},
 			wantErr:  true,
@@ -145,7 +157,7 @@ func TestValidateSetupInputs(t *testing.T) {
 				t.Setenv("GH_APP_PRIVATE_KEY", "")
 			}
 
-			err := validateSetupInputs(tt.appID, tt.patterns, &useKeyring, &useFilesystem, keyFile)
+			err := validateSetupInputs(tt.appID, tt.clientID, tt.patterns, &useKeyring, &useFilesystem, keyFile)
 
 			if tt.wantErr {
 				if err == nil {
@@ -292,11 +304,13 @@ func TestCreateGitHubApp(t *testing.T) {
 	tests := []struct {
 		name           string
 		appID          int64
+		clientID       string
 		appName        string
 		installationID int64
 		patterns       []string
 		priority       int
 		wantName       string
+		wantClientID   string
 		wantErr        bool
 	}{
 		{
@@ -320,6 +334,17 @@ func TestCreateGitHubApp(t *testing.T) {
 			wantErr:        false, // No validation in createGitHubApp anymore
 		},
 		{
+			name:           "with client id default name",
+			clientID:       "Iv1.AbCdEfGhIjKlMn",
+			appName:        "",
+			installationID: 789,
+			patterns:       []string{"github.com/org/*"},
+			priority:       5,
+			wantName:       "GitHub App Iv1.AbCdEfGhIjKlMn",
+			wantClientID:   "Iv1.AbCdEfGhIjKlMn",
+			wantErr:        false,
+		},
+		{
 			name:           "with multiple patterns",
 			appID:          123456,
 			appName:        "Test",
@@ -333,7 +358,7 @@ func TestCreateGitHubApp(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			app := createGitHubApp(tt.appID, tt.appName, tt.installationID, tt.patterns, tt.priority)
+			app := createGitHubApp(tt.appID, tt.clientID, tt.appName, tt.installationID, tt.patterns, tt.priority)
 
 			if app.Name != tt.wantName {
 				t.Errorf("Name = %q, want %q", app.Name, tt.wantName)
@@ -341,6 +366,10 @@ func TestCreateGitHubApp(t *testing.T) {
 
 			if app.AppID != tt.appID {
 				t.Errorf("AppID = %d, want %d", app.AppID, tt.appID)
+			}
+
+			if app.ClientID != tt.wantClientID {
+				t.Errorf("ClientID = %q, want %q", app.ClientID, tt.wantClientID)
 			}
 
 			if app.InstallationID != tt.installationID {
@@ -418,13 +447,34 @@ func TestExpandPath(t *testing.T) {
 func TestGenerateJWTForSetup(t *testing.T) {
 	validKey := generateTestRSAKey(t)
 
-	t.Run("valid JWT generation", func(t *testing.T) {
+	t.Run("valid JWT generation with app ID", func(t *testing.T) {
 		token, err := generateJWTForSetup(123456, validKey)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		if token == "" {
 			t.Error("Expected non-empty token")
+		}
+	})
+
+	t.Run("valid JWT generation with client ID", func(t *testing.T) {
+		token, err := generateJWTForSetup("Iv1.AbCdEfGhIjKlMn", validKey)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if token == "" {
+			t.Error("Expected non-empty token")
+		}
+
+		// Verify the token contains the client ID as the issuer
+		gen := jwt.NewGenerator()
+		claims, err := gen.GetTokenClaims(token)
+		if err != nil {
+			t.Fatalf("Failed to get token claims: %v", err)
+		}
+		iss, ok := claims["iss"].(string)
+		if !ok || iss != "Iv1.AbCdEfGhIjKlMn" {
+			t.Errorf("Token iss = %v (%T), want string Iv1.AbCdEfGhIjKlMn", claims["iss"], claims["iss"])
 		}
 	})
 
@@ -659,6 +709,21 @@ func TestSetupRun_Integration(t *testing.T) {
 		}
 	})
 
+	t.Run("setup with client id recognized as app setup", func(t *testing.T) {
+		// Clear config
+		os.Remove(configPath)
+
+		cmd := NewSetupCmd()
+		cmd.Flags().Set("client-id", "Iv1.AbCdEfGhIjKlMn")
+		cmd.Flags().Set("key-file", keyPath)
+
+		// Missing pattern should still be caught, proving client-id is accepted as app setup
+		err := cmd.Execute()
+		if err == nil {
+			t.Error("Expected error for missing pattern")
+		}
+	})
+
 	t.Run("setup with invalid key file", func(t *testing.T) {
 		// Clear config
 		os.Remove(configPath)
@@ -712,7 +777,7 @@ func TestSetupRun_Integration(t *testing.T) {
 		priority := 5
 
 		// Create the app without validation
-		app := createGitHubApp(appID, name, installationID, patterns, priority)
+		app := createGitHubApp(appID, "", name, installationID, patterns, priority)
 
 		// At this point, app should have no PrivateKeySource or PrivateKeyPath set
 		if app.PrivateKeySource != "" {
@@ -1024,7 +1089,8 @@ func TestDisplaySetupSuccess(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Just verify it doesn't panic
-			displaySetupSuccess(tt.appName, tt.appID, tt.patterns, tt.priority, tt.backend, tt.expandedKeyFile)
+			identifier := fmt.Sprintf("%d", tt.appID)
+			displaySetupSuccess(tt.appName, identifier, tt.patterns, tt.priority, tt.backend, tt.expandedKeyFile)
 		})
 	}
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -14,6 +16,7 @@ import (
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/auth"
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/secrets"
+	"github.com/cli/go-gh/v2/pkg/repository"
 	"github.com/spf13/cobra"
 )
 
@@ -95,8 +98,51 @@ func testRun(repo *string, verbose *bool) func(*cobra.Command, []string) error {
 }
 
 func getCurrentRepository() (string, error) {
-	// This is a placeholder - in reality we'd use go-gh's repository detection
-	return "", fmt.Errorf("current repository detection not implemented yet")
+	if override := os.Getenv("GH_REPO"); override != "" {
+		return canonicalRepository(override)
+	}
+
+	remoteURL, err := currentGitRemoteURL()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine current repository: %w", err)
+	}
+	return canonicalRepository(remoteURL)
+}
+
+func currentGitRemoteURL() (string, error) {
+	if output, err := exec.Command("git", "config", "--local", "--get", "remote.origin.url").Output(); err == nil {
+		return strings.TrimSpace(string(output)), nil
+	}
+
+	output, err := exec.Command("git", "config", "--local", "--get-regexp", `^remote\..*\.url$`).CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && message == "" {
+			return "", fmt.Errorf("no git remotes configured for this repository")
+		}
+		if message != "" {
+			return "", fmt.Errorf("failed to read git remotes: %w: %s", err, message)
+		}
+		return "", fmt.Errorf("failed to read git remotes: %w", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 {
+			return fields[len(fields)-1], nil
+		}
+	}
+
+	return "", fmt.Errorf("no git remotes configured for this repository")
+}
+
+func canonicalRepository(value string) (string, error) {
+	repo, err := repository.Parse(value)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s/%s/%s", repo.Host, repo.Owner, repo.Name), nil
 }
 
 func testAPIAccess(token, repoURL string, verbose bool) error {
@@ -109,7 +155,7 @@ func testAPIAccess(token, repoURL string, verbose bool) error {
 
 	// Use raw HTTP instead of go-gh to avoid GitHub CLI auth requirement
 	apiURL := fmt.Sprintf("https://%s/api/v3/repos/%s/%s", host, owner, repo)
-	if host == "github.com" {
+	if host == gitHubAPIHost {
 		apiURL = fmt.Sprintf("https://api.github.com/repos/%s/%s", owner, repo)
 	}
 
@@ -181,7 +227,7 @@ func extractHost(repoURL string) string {
 	}
 
 	// Default to github.com
-	return "github.com"
+	return gitHubAPIHost
 }
 
 func extractOwnerRepo(repoURL string) (owner, repo string, err error) {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -274,7 +274,7 @@ func runAuthenticationTests(cfg *config.Config, repoURL string, verbose bool) er
 	}
 
 	if verbose {
-		fmt.Printf("✅ Found matching app: %s (ID: %d)\n", matchedApp.Name, matchedApp.AppID)
+		fmt.Printf("✅ Found matching app: %s (ID: %s)\n", matchedApp.Name, matchedApp.GetIdentifier())
 		fmt.Printf("   Patterns: %v\n", matchedApp.Patterns)
 		fmt.Printf("   Priority: %d\n\n", matchedApp.Priority)
 	} else {

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -3,12 +3,14 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
 	"gopkg.in/yaml.v3"
@@ -784,4 +786,83 @@ YqJP8ECgYEA6i9AxVPQpV8JqCGXQHMYqGHQVPGqJqLGYPqQJ8xGLqYPHqmQGYqJP
 			t.Error("Expected error for non-matching repo")
 		}
 	})
+}
+
+func TestRunAuthenticationTests_Verbose(t *testing.T) {
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "test-key.pem")
+
+	testKey := generateTestRSAKey(t)
+	if err := os.WriteFile(keyPath, []byte(testKey), 0600); err != nil {
+		t.Fatalf("Failed to write test key: %v", err)
+	}
+
+	cfg := &config.Config{
+		Version: "1.0",
+		GitHubApps: []config.GitHubApp{
+			{
+				Name:             "Verbose App",
+				ClientID:         "Iv1.Verbose",
+				InstallationID:   789012,
+				Patterns:         []string{"github.com/org/*"},
+				PrivateKeySource: config.PrivateKeySourceFilesystem,
+				PrivateKeyPath:   keyPath,
+			},
+		},
+	}
+
+	err := runAuthenticationTests(cfg, "https://github.com/org/repo", true)
+	if err == nil {
+		t.Error("Expected network error after verbose matching output")
+	}
+}
+
+func TestRunAuthenticationTests_Success(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			expiresAt := time.Now().Add(time.Hour).Format(time.RFC3339)
+			_, _ = fmt.Fprintf(w, `{"token":"mock-installation-token","expires_at":"%s"}`, expiresAt)
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"name":"repo","full_name":"org/repo","private":false}`)
+		default:
+			t.Errorf("Unexpected %s request to %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = server.Client().Transport
+	defer func() { http.DefaultTransport = oldTransport }()
+
+	host := server.Listener.Addr().String()
+
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "test-key.pem")
+	testKey := generateTestRSAKey(t)
+	if err := os.WriteFile(keyPath, []byte(testKey), 0600); err != nil {
+		t.Fatalf("Failed to write test key: %v", err)
+	}
+
+	cfg := &config.Config{
+		Version: "1.0",
+		GitHubApps: []config.GitHubApp{
+			{
+				Name:             "Success App",
+				ClientID:         "Iv1.Success",
+				InstallationID:   789012,
+				Patterns:         []string{fmt.Sprintf("%s/org/*", host)},
+				PrivateKeySource: config.PrivateKeySourceFilesystem,
+				PrivateKeyPath:   keyPath,
+			},
+		},
+	}
+
+	repoURL := fmt.Sprintf("https://%s/org/repo", host)
+	err := runAuthenticationTests(cfg, repoURL, true)
+	if err != nil {
+		t.Errorf("runAuthenticationTests() error = %v", err)
+	}
 }

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -167,12 +168,43 @@ func TestExtractOwnerRepo(t *testing.T) {
 }
 
 func TestGetCurrentRepository(t *testing.T) {
-	t.Run("not implemented", func(t *testing.T) {
-		_, err := getCurrentRepository()
-		if err == nil {
-			t.Error("Expected error for not implemented function")
-		}
-	})
+	tempDir := t.TempDir()
+	runGit(t, tempDir, "init")
+	runGit(t, tempDir, "remote", "add", "origin", "git@github.com:myorg/myrepo.git")
+	withWorkingDirectory(t, tempDir)
+	t.Setenv("HOME", t.TempDir())
+
+	got, err := getCurrentRepository()
+	if err != nil {
+		t.Fatalf("getCurrentRepository() error = %v", err)
+	}
+	if got != "github.com/myorg/myrepo" {
+		t.Errorf("getCurrentRepository() = %q, want %q", got, "github.com/myorg/myrepo")
+	}
+}
+
+func TestGetCurrentRepositoryFromEnvironment(t *testing.T) {
+	t.Setenv("GH_REPO", "github.example.com/myorg/myrepo")
+
+	got, err := getCurrentRepository()
+	if err != nil {
+		t.Fatalf("getCurrentRepository() error = %v", err)
+	}
+	if got != "github.example.com/myorg/myrepo" {
+		t.Errorf("getCurrentRepository() = %q, want %q", got, "github.example.com/myorg/myrepo")
+	}
+}
+
+func TestCurrentGitRemoteURLPreservesGitError(t *testing.T) {
+	withWorkingDirectory(t, t.TempDir())
+
+	_, err := currentGitRemoteURL()
+	if err == nil {
+		t.Fatal("currentGitRemoteURL() error = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "failed to read git remotes") || !strings.Contains(err.Error(), "fatal:") {
+		t.Errorf("currentGitRemoteURL() error = %q, want git diagnostic", err)
+	}
 }
 
 func TestDetermineRepositoryURL(t *testing.T) {
@@ -185,11 +217,6 @@ func TestDetermineRepositoryURL(t *testing.T) {
 			name:    "with repo specified",
 			repo:    "https://github.com/myorg/myrepo",
 			wantErr: false,
-		},
-		{
-			name:    "without repo - should fail",
-			repo:    "",
-			wantErr: true,
 		},
 	}
 
@@ -214,6 +241,39 @@ func TestDetermineRepositoryURL(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("without repo outside git repository", func(t *testing.T) {
+		withWorkingDirectory(t, t.TempDir())
+		_, err := determineRepositoryURL("")
+		if err == nil {
+			t.Fatal("determineRepositoryURL() error = nil, want an error")
+		}
+	})
+}
+
+func runGit(t *testing.T, directory string, args ...string) {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = directory
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
+func withWorkingDirectory(t *testing.T, directory string) {
+	t.Helper()
+	original, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd() error = %v", err)
+	}
+	if err := os.Chdir(directory); err != nil {
+		t.Fatalf("os.Chdir(%q) error = %v", directory, err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(original); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	})
 }
 
 func TestDisplayTestResults(t *testing.T) {

--- a/docs/GITCONFIG_COMMAND.md
+++ b/docs/GITCONFIG_COMMAND.md
@@ -132,7 +132,7 @@ gh app-auth gitconfig --sync --auto
 **Requirements:**
 
 - `GH_APP_PRIVATE_KEY_PATH` environment variable must be set (path to private key file)
-- `GH_APP_ID` environment variable must be set
+- `GH_APP_ID` or `GH_APP_CLIENT_ID` environment variable must be set
 
 **How it works:**
 
@@ -150,7 +150,7 @@ gh app-auth gitconfig --sync --auto
 
 ```bash
 export GH_APP_PRIVATE_KEY_PATH="/path/to/app.pem"
-export GH_APP_ID="123456"
+export GH_APP_CLIENT_ID="Iv1.your_client_id"
 gh app-auth gitconfig --sync --auto
 
 # Now any git clone will use the GitHub App

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,7 @@ At least one GitHub App or PAT must be present.
 
 ```yaml
 - name: Org Automation App
-  app_id: 123456
+  client_id: Iv1.AbCdEfGhIjKlMn  # preferred identifier (alternative: app_id)
   installation_id: 987654        # optional (auto-detect)
   private_key_source: keyring    # keyring | filesystem | inline (legacy)
   private_key_path: ~/.keys/app.pem  # only used when source=filesystem
@@ -83,7 +83,8 @@ At least one GitHub App or PAT must be present.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | ✅ | Friendly label shown in `gh app-auth list`. |
-| `app_id` | int | ✅ | GitHub App ID. |
+| `app_id` | int | ➖ | GitHub App ID (legacy; `client_id` is preferred). |
+| `client_id` | string | ➖ | GitHub App Client ID (e.g. `Iv1...`). At least one of `app_id` or `client_id` is required. |
 | `installation_id` | int | ➖ | Optional override. If omitted, auto-detection is attempted during `setup`. |
 | `private_key_source` | enum | ✅ | `keyring`, `filesystem`, or `inline` (legacy). Indicates where the key material lives after setup. |
 | `private_key_path` | string | ➖ | Populated when `private_key_source=filesystem`. |

--- a/main.go
+++ b/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/AmadeusITGroup/gh-app-auth/cmd"
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/logger"
@@ -13,6 +15,11 @@ func main() {
 	logger.Initialize()
 
 	if err := cmd.Execute(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			logger.Close()
+			os.Exit(exitErr.ExitCode())
+		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		logger.Close()
 		os.Exit(1)

--- a/pkg/auth/auth_integration_test.go
+++ b/pkg/auth/auth_integration_test.go
@@ -510,3 +510,30 @@ func TestGetInstallationToken_WithMock(t *testing.T) {
 		})
 	}
 }
+
+func TestGetCredentials_WithClientID(t *testing.T) {
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "test-key.pem")
+
+	keyContent := generateTestRSAKey(t)
+	if err := os.WriteFile(keyPath, []byte(keyContent), 0600); err != nil {
+		t.Fatalf("Failed to write test key: %v", err)
+	}
+
+	app := &config.GitHubApp{
+		Name:             "Client ID App",
+		ClientID:         "Iv1.Credentials",
+		InstallationID:   789012,
+		Patterns:         []string{"github.com/org/*"},
+		PrivateKeySource: config.PrivateKeySourceFilesystem,
+		PrivateKeyPath:   keyPath,
+	}
+
+	auth := NewAuthenticator()
+	_, _, err := auth.GetCredentials(app, "https://github.com/org/repo")
+	// The request will fail because there is no real GitHub App for the client ID,
+	// but this exercises the GetIdentifier/GetIssuer paths introduced for client IDs.
+	if err == nil {
+		t.Error("Expected network error when using test client ID")
+	}
+}

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -49,7 +49,7 @@ func NewAuthenticator() *Authenticator {
 // GetCredentials returns username and token for git credential helper.
 func (a *Authenticator) GetCredentials(app *config.GitHubApp, repoURL string) (token, username string, err error) {
 	// Generate cache key
-	cacheKey := cache.CreateCacheKey(app.AppID, app.InstallationID)
+	cacheKey := cache.CreateCacheKey(app.GetIdentifier(), app.InstallationID)
 
 	// Check cache first
 	if cachedToken, found := a.tokenCache.Get(cacheKey); found {
@@ -64,7 +64,7 @@ func (a *Authenticator) GetCredentials(app *config.GitHubApp, repoURL string) (t
 	}
 
 	// Generate JWT token
-	jwtToken, err := a.jwtGenerator.GenerateTokenFromKey(app.AppID, privateKey)
+	jwtToken, err := a.jwtGenerator.GenerateTokenFromKey(app.GetIssuer(), privateKey)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to generate JWT: %w", err)
 	}
@@ -85,8 +85,9 @@ func (a *Authenticator) GetCredentials(app *config.GitHubApp, repoURL string) (t
 }
 
 // GenerateJWT generates a JWT token for the GitHub App (legacy file-based method).
-func (a *Authenticator) GenerateJWT(appID int64, privateKeyPath string) (string, error) {
-	return a.jwtGenerator.GenerateToken(appID, privateKeyPath)
+// The issuer may be the numeric App ID (int64) or the Client ID (string).
+func (a *Authenticator) GenerateJWT(issuer any, privateKeyPath string) (string, error) {
+	return a.jwtGenerator.GenerateToken(issuer, privateKeyPath)
 }
 
 // GenerateJWTForApp generates a JWT token using the app's configured private key source.
@@ -98,7 +99,7 @@ func (a *Authenticator) GenerateJWTForApp(app *config.GitHubApp) (string, error)
 	}
 
 	// Generate JWT token
-	return a.jwtGenerator.GenerateTokenFromKey(app.AppID, privateKey)
+	return a.jwtGenerator.GenerateTokenFromKey(app.GetIssuer(), privateKey)
 }
 
 // GetInstallationToken exchanges JWT for an installation access token.

--- a/pkg/auth/generate_jwt_test.go
+++ b/pkg/auth/generate_jwt_test.go
@@ -192,3 +192,43 @@ func TestGenerateJWT_Consistency(t *testing.T) {
 	// Note: Tokens may be identical if generated in the same second
 	// This is expected behavior for JWT tokens with 1-second granularity
 }
+
+func TestGenerateJWT_WithClientID(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate RSA key: %v", err)
+	}
+
+	tempFile, err := os.CreateTemp("", "test-key-*.pem")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+	privateKeyPEM := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: privateKeyBytes,
+	}
+
+	if err := pem.Encode(tempFile, privateKeyPEM); err != nil {
+		t.Fatalf("Failed to encode PEM: %v", err)
+	}
+	tempFile.Close()
+
+	auth := NewAuthenticator()
+
+	token, err := auth.GenerateJWT("Iv1.ClientID", tempFile.Name())
+	if err != nil {
+		t.Fatalf("GenerateJWT() error = %v", err)
+	}
+
+	if token == "" {
+		t.Error("Expected non-empty token")
+	}
+
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Errorf("Expected 3 JWT parts, got %d", len(parts))
+	}
+}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -193,7 +193,8 @@ func (c *TokenCache) zeroToken(token string) {
 	runtime.GC()
 }
 
-// CreateCacheKey creates a cache key for a specific app configuration
-func CreateCacheKey(appID, installationID int64) string {
-	return fmt.Sprintf("app_%d_inst_%d", appID, installationID)
+// CreateCacheKey creates a cache key for a specific app configuration.
+// The appIdentifier may be a numeric App ID string or a Client ID.
+func CreateCacheKey(appIdentifier string, installationID int64) string {
+	return fmt.Sprintf("app_%s_inst_%d", appIdentifier, installationID)
 }

--- a/pkg/cache/cache_edge_test.go
+++ b/pkg/cache/cache_edge_test.go
@@ -109,21 +109,28 @@ func TestTokenCache_SizeIncreases(t *testing.T) {
 }
 
 func TestCreateCacheKey_Consistency(t *testing.T) {
-	appID := int64(123456)
+	appIdentifier := "123456"
 	installID := int64(789012)
 
 	// Should generate same key for same inputs
-	key1 := CreateCacheKey(appID, installID)
-	key2 := CreateCacheKey(appID, installID)
+	key1 := CreateCacheKey(appIdentifier, installID)
+	key2 := CreateCacheKey(appIdentifier, installID)
 
 	if key1 != key2 {
 		t.Errorf("Keys should be identical: %q vs %q", key1, key2)
 	}
 
 	// Different inputs should generate different keys
-	key3 := CreateCacheKey(appID, 999999)
+	key3 := CreateCacheKey(appIdentifier, 999999)
 	if key1 == key3 {
 		t.Error("Different installation IDs should generate different keys")
+	}
+
+	// Numeric app ID string and Client ID must not collide
+	key4 := CreateCacheKey("123456", installID)
+	key5 := CreateCacheKey("Iv1.123456", installID)
+	if key4 == key5 {
+		t.Error("Numeric app ID and Client ID should generate different keys")
 	}
 }
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -242,33 +242,39 @@ func TestTokenCache_Cleanup(t *testing.T) {
 func TestCreateCacheKey(t *testing.T) {
 	tests := []struct {
 		name           string
-		appID          int64
+		appIdentifier  string
 		installationID int64
 		expected       string
 	}{
 		{
-			name:           "positive IDs",
-			appID:          12345,
+			name:           "positive app ID",
+			appIdentifier:  "12345",
 			installationID: 67890,
 			expected:       "app_12345_inst_67890",
 		},
 		{
 			name:           "zero IDs",
-			appID:          0,
+			appIdentifier:  "0",
 			installationID: 0,
 			expected:       "app_0_inst_0",
 		},
 		{
-			name:           "large IDs",
-			appID:          999999999999,
+			name:           "large app ID",
+			appIdentifier:  "999999999999",
 			installationID: 888888888888,
 			expected:       "app_999999999999_inst_888888888888",
+		},
+		{
+			name:           "client ID",
+			appIdentifier:  "Iv1.AbCdEfGhIjKlMn",
+			installationID: 67890,
+			expected:       "app_Iv1.AbCdEfGhIjKlMn_inst_67890",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := CreateCacheKey(tt.appID, tt.installationID)
+			result := CreateCacheKey(tt.appIdentifier, tt.installationID)
 			if result != tt.expected {
 				t.Errorf("CreateCacheKey() = %v, want %v", result, tt.expected)
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -62,13 +63,32 @@ type RepositoryInfo struct {
 // GitHubApp represents a single GitHub App configuration
 type GitHubApp struct {
 	Name             string             `yaml:"name" json:"name"`
-	AppID            int64              `yaml:"app_id" json:"app_id"`
+	AppID            int64              `yaml:"app_id,omitempty" json:"app_id,omitempty"`
+	ClientID         string             `yaml:"client_id,omitempty" json:"client_id,omitempty"`
 	InstallationID   int64              `yaml:"installation_id" json:"installation_id"`
 	PrivateKeyPath   string             `yaml:"private_key_path,omitempty" json:"private_key_path,omitempty"`
 	PrivateKeySource PrivateKeySource   `yaml:"private_key_source,omitempty" json:"private_key_source,omitempty"`
 	Patterns         []string           `yaml:"patterns" json:"patterns"`
 	Priority         int                `yaml:"priority" json:"priority"` // Deprecated: Ignored in favor of longest prefix
 	Scope            *InstallationScope `yaml:"scope,omitempty" json:"scope,omitempty"`
+}
+
+// GetIdentifier returns the public identifier for the GitHub App.
+// Client ID is preferred when present; otherwise the numeric App ID is returned as a string.
+func (g *GitHubApp) GetIdentifier() string {
+	if g.ClientID != "" {
+		return g.ClientID
+	}
+	return strconv.FormatInt(g.AppID, 10)
+}
+
+// GetIssuer returns the value to use as the JWT iss claim.
+// It returns the Client ID string when available, otherwise the numeric App ID.
+func (g *GitHubApp) GetIssuer() any {
+	if g.ClientID != "" {
+		return g.ClientID
+	}
+	return g.AppID
 }
 
 type PersonalAccessToken struct {
@@ -178,8 +198,12 @@ func (g *GitHubApp) validateBasicFields() error {
 		return fmt.Errorf("name is required")
 	}
 
-	if g.AppID <= 0 {
+	if g.AppID < 0 {
 		return fmt.Errorf("app_id must be positive")
+	}
+
+	if g.AppID == 0 && g.ClientID == "" {
+		return fmt.Errorf("app_id or client_id is required")
 	}
 
 	// InstallationID can be 0 (auto-detected at runtime via GitHub API)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -132,7 +132,44 @@ func TestGitHubApp_Validate(t *testing.T) {
 				Priority:       100,
 			},
 			wantErr: true,
-			errMsg:  "app_id must be positive",
+			errMsg:  "app_id or client_id is required",
+		},
+		{
+			name: "valid app with client_id only",
+			app: GitHubApp{
+				Name:           "test-app",
+				ClientID:       "Iv1.AbCdEfGhIjKlMn",
+				InstallationID: 67890,
+				PrivateKeyPath: "/tmp/key.pem",
+				Patterns:       []string{"github.com/org/*"},
+				Priority:       100,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid app with both app_id and client_id",
+			app: GitHubApp{
+				Name:           "test-app",
+				AppID:          12345,
+				ClientID:       "Iv1.AbCdEfGhIjKlMn",
+				InstallationID: 67890,
+				PrivateKeyPath: "/tmp/key.pem",
+				Patterns:       []string{"github.com/org/*"},
+				Priority:       100,
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing app_id and client_id",
+			app: GitHubApp{
+				Name:           "test-app",
+				InstallationID: 67890,
+				PrivateKeyPath: "/tmp/key.pem",
+				Patterns:       []string{"github.com/org/*"},
+				Priority:       100,
+			},
+			wantErr: true,
+			errMsg:  "app_id or client_id is required",
 		},
 		{
 			name: "valid app with auto-detect installation_id",
@@ -322,5 +359,44 @@ func TestConfig_GetByPriority(t *testing.T) {
 	// Verify original config is not modified
 	if config.GitHubApps[0].Name != "low-priority" {
 		t.Error("GetByPriority() modified the original config")
+	}
+}
+
+func TestGitHubApp_GetIdentifier(t *testing.T) {
+	tests := []struct {
+		name       string
+		app        GitHubApp
+		want       string
+		wantIssuer any
+	}{
+		{
+			name:       "client_id preferred",
+			app:        GitHubApp{Name: "app", ClientID: "Iv1.XyZ", AppID: 12345},
+			want:       "Iv1.XyZ",
+			wantIssuer: "Iv1.XyZ",
+		},
+		{
+			name:       "app_id fallback",
+			app:        GitHubApp{Name: "app", AppID: 12345},
+			want:       "12345",
+			wantIssuer: int64(12345),
+		},
+		{
+			name:       "client_id only",
+			app:        GitHubApp{Name: "app", ClientID: "Iv1.AbCd"},
+			want:       "Iv1.AbCd",
+			wantIssuer: "Iv1.AbCd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.app.GetIdentifier(); got != tt.want {
+				t.Errorf("GetIdentifier() = %q, want %q", got, tt.want)
+			}
+			if got := tt.app.GetIssuer(); got != tt.wantIssuer {
+				t.Errorf("GetIssuer() = %v (%T), want %v (%T)", got, got, tt.wantIssuer, tt.wantIssuer)
+			}
+		})
 	}
 }

--- a/pkg/config/extension.go
+++ b/pkg/config/extension.go
@@ -78,7 +78,7 @@ func (c *Config) AddOrUpdateApp(app *GitHubApp) {
 	// Check if app already exists
 	for i, existingApp := range c.GitHubApps {
 		// Update existing app
-		if existingApp.AppID == app.AppID && existingApp.InstallationID == app.InstallationID {
+		if existingApp.GetIdentifier() == app.GetIdentifier() && existingApp.InstallationID == app.InstallationID {
 			// Merge patterns from new app into existing app
 			mergedPatterns := mergePatterns(existingApp.Patterns, app.Patterns)
 			app.Patterns = mergedPatterns

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -106,6 +106,38 @@ func TestGitHubApp_Validate_EdgeCases(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "client_id only",
+			app: GitHubApp{
+				Name:           "Test",
+				ClientID:       "Iv1.AbCdEfGhIjKlMn",
+				InstallationID: 456,
+				PrivateKeyPath: "/tmp/key.pem",
+				Patterns:       []string{"github.com/org/*"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "client_id and app_id",
+			app: GitHubApp{
+				Name:           "Test",
+				AppID:          123,
+				ClientID:       "Iv1.AbCdEfGhIjKlMn",
+				InstallationID: 456,
+				PrivateKeyPath: "/tmp/key.pem",
+				Patterns:       []string{"github.com/org/*"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing app_id and client_id",
+			app: GitHubApp{
+				Name:           "Test",
+				InstallationID: 456,
+				Patterns:       []string{"github.com/org/*"},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/jwt/generator.go
+++ b/pkg/jwt/generator.go
@@ -31,8 +31,9 @@ func NewGenerator() *Generator {
 	}
 }
 
-// GenerateToken generates a GitHub App JWT token from a private key file path
-func (g *Generator) GenerateToken(appID int64, privateKeyPath string) (string, error) {
+// GenerateToken generates a GitHub App JWT token from a private key file path.
+// The issuer may be the numeric App ID (int64) or the Client ID (string).
+func (g *Generator) GenerateToken(issuer any, privateKeyPath string) (string, error) {
 	// Load private key
 	privateKey, err := g.loadPrivateKey(privateKeyPath)
 	if err != nil {
@@ -40,23 +41,24 @@ func (g *Generator) GenerateToken(appID int64, privateKeyPath string) (string, e
 	}
 
 	// Create JWT token
-	token, err := g.createJWT(appID, privateKey)
+	token, err := g.createJWT(issuer, privateKey)
 	if err != nil {
 		return "", fmt.Errorf("failed to create JWT: %w", err)
 	}
 	return token, nil
 }
 
-// GenerateTokenFromKey generates a GitHub App JWT token from private key content
-func (g *Generator) GenerateTokenFromKey(appID int64, privateKeyContent string) (string, error) {
+// GenerateTokenFromKey generates a GitHub App JWT token from private key content.
+// The issuer may be the numeric App ID (int64) or the Client ID (string).
+func (g *Generator) GenerateTokenFromKey(issuer any, privateKeyContent string) (string, error) {
 	// Check cache first (read lock)
-	cacheKey := fmt.Sprintf("%d", appID)
+	cacheKey := g.issuerCacheKey(issuer)
 	g.mu.RLock()
 	cachedKey, exists := g.keyCache[cacheKey]
 	g.mu.RUnlock()
 
 	if exists {
-		return g.createJWT(appID, cachedKey)
+		return g.createJWT(issuer, cachedKey)
 	}
 
 	// Parse private key from content
@@ -71,11 +73,17 @@ func (g *Generator) GenerateTokenFromKey(appID int64, privateKeyContent string) 
 	g.mu.Unlock()
 
 	// Create JWT token
-	token, err := g.createJWT(appID, privateKey)
+	token, err := g.createJWT(issuer, privateKey)
 	if err != nil {
 		return "", fmt.Errorf("failed to create JWT: %w", err)
 	}
 	return token, nil
+}
+
+// issuerCacheKey returns a unique string key for the issuer value.
+// The type is encoded to avoid collisions between a numeric string and an int64.
+func (g *Generator) issuerCacheKey(issuer any) string {
+	return fmt.Sprintf("%T:%v", issuer, issuer)
 }
 
 // loadPrivateKey loads and parses an RSA private key from a PEM file
@@ -144,8 +152,9 @@ func (g *Generator) parsePrivateKey(keyData []byte) (*rsa.PrivateKey, error) {
 	return privateKey, nil
 }
 
-// createJWT creates a GitHub App JWT token
-func (g *Generator) createJWT(appID int64, privateKey *rsa.PrivateKey) (string, error) {
+// createJWT creates a GitHub App JWT token.
+// The issuer may be the numeric App ID (int64) or the Client ID (string).
+func (g *Generator) createJWT(issuer any, privateKey *rsa.PrivateKey) (string, error) {
 	// JWT Header
 	header := map[string]interface{}{
 		"alg": "RS256",
@@ -155,7 +164,7 @@ func (g *Generator) createJWT(appID int64, privateKey *rsa.PrivateKey) (string, 
 	// JWT Payload
 	now := time.Now()
 	payload := map[string]interface{}{
-		"iss": appID,
+		"iss": issuer,
 		"iat": now.Unix(),
 		"exp": now.Add(10 * time.Minute).Unix(), // GitHub Apps tokens expire in 10 minutes max
 	}

--- a/pkg/jwt/generator_integration_test.go
+++ b/pkg/jwt/generator_integration_test.go
@@ -106,6 +106,30 @@ func TestGenerateTokenFromKey(t *testing.T) {
 	}
 }
 
+func TestGenerateTokenFromKey_WithClientID(t *testing.T) {
+	privateKey := generateTestRSAKey(t)
+	gen := NewGenerator()
+	clientID := "Iv1.AbCdEfGhIjKlMn"
+
+	token, err := gen.GenerateTokenFromKey(clientID, privateKey)
+	if err != nil {
+		t.Fatalf("GenerateTokenFromKey() error = %v", err)
+	}
+
+	claims, err := gen.GetTokenClaims(token)
+	if err != nil {
+		t.Fatalf("GetTokenClaims() error = %v", err)
+	}
+
+	iss, ok := claims["iss"].(string)
+	if !ok {
+		t.Fatalf("iss claim type = %T, want string", claims["iss"])
+	}
+	if iss != clientID {
+		t.Errorf("iss claim = %q, want %q", iss, clientID)
+	}
+}
+
 func TestValidateToken_WithRealKey(t *testing.T) {
 	privateKey := generateTestRSAKey(t)
 	gen := NewGenerator()

--- a/pkg/jwt/generator_test.go
+++ b/pkg/jwt/generator_test.go
@@ -286,6 +286,35 @@ func TestGenerator_GenerateToken_Errors(t *testing.T) {
 	}
 }
 
+func TestGenerator_GenerateToken_WithClientID(t *testing.T) {
+	generator := NewGenerator()
+	testKey, err := generateTestKey()
+	if err != nil {
+		t.Fatalf("Failed to generate test key: %v", err)
+	}
+
+	clientID := "Iv1.AbCdEfGhIjKlMn"
+	keyPath := writeTestKeyFile(t, testKey, "pkcs1")
+
+	token, err := generator.GenerateToken(clientID, keyPath)
+	if err != nil {
+		t.Fatalf("GenerateToken() error = %v", err)
+	}
+
+	claims, err := generator.GetTokenClaims(token)
+	if err != nil {
+		t.Fatalf("Failed to get token claims: %v", err)
+	}
+
+	iss, ok := claims["iss"].(string)
+	if !ok {
+		t.Errorf("Token iss claim = %v (%T), want string", claims["iss"], claims["iss"])
+	}
+	if iss != clientID {
+		t.Errorf("Token iss claim = %q, want %q", iss, clientID)
+	}
+}
+
 func TestGenerator_ValidateToken(t *testing.T) {
 	generator := NewGenerator()
 


### PR DESCRIPTION
## Description

Add support for GitHub's alphanumeric **Client ID** (`Iv1.xxxx`) as an alternative to the numeric App ID for authenticating GitHub Apps. The existing numeric App ID workflow continues to work unchanged.

Closes #52

## Type of Change

Please delete options that are not relevant:

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes, no api changes)
- [ ] ⚡ Performance improvements
- [x] 🧪 Test updates
- [ ] 🔒 Security improvements

## Changes Made

- Added `ClientID` to the `GitHubApp` configuration and exposed `GetIdentifier()` / `GetIssuer()` helpers.
- Updated `pkg/jwt` to accept `issuer any` so the JWT `iss` claim can be a string Client ID or numeric App ID.
- Updated `pkg/cache` and `pkg/auth` to use the new string identifier for cache keys and token generation.
- Added `--client-id` support to `setup`, `remove`, and the hidden `debug list-installations` / `debug list-repositories` commands.
- Updated `gh app-auth gitconfig --auto` to read `GH_APP_CLIENT_ID` in addition to `GH_APP_ID`.
- Updated README, `docs/configuration.md`, and `docs/GITCONFIG_COMMAND.md` with Client ID examples.
- Pinned `golangci-lint` in the Makefile to `v2.1.6` to match the GitHub CI version.

## Testing

Please describe the tests that you ran to verify your changes:

- [x] Unit tests pass: `go test ./...`
- [x] Build succeeds: `go build -o gh-app-auth .`
- [x] Manual testing performed (`make ci`)
- [ ] Integration tests with real GitHub Apps (if applicable)

### Test Configuration

- **OS**: Linux
- **Go version**: 1.25
- **GitHub CLI version**: N/A

## Security Considerations

If this PR involves security-related changes:

- [x] No sensitive data (tokens, keys) exposed in code or tests
- [x] Input validation added/reviewed for new functionality
- [x] Private key handling follows security best practices
- [x] Token caching security maintained
- [x] No new attack vectors introduced

## Documentation

- [x] Code comments updated
- [x] README.md updated (if needed)
- [ ] Architecture documentation updated (if needed)
- [x] Command help text updated (if needed)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] **Commit messages follow [Conventional Commits](https://github.com/AmadeusITGroup/gh-app-auth/blob/main/CONTRIBUTING.md#commit-message-guidelines) format**
- [x] **PR title follows conventional commits format** (e.g., `feat(auth): add token caching`)

## Breaking Changes

None. Existing configurations using `app_id` / `--app-id` continue to work unchanged.

## Additional Notes

- The hidden `debug` commands now also support `--client-id` filtering; they were the last commands without full Client ID support.
- `make ci` completes successfully with `golangci-lint` v2.1.6.
