### PR TITLE
fix(auth): leave clock skew margin on JWT exp and iat claims

### DIFF
--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -320,7 +320,7 @@ func listInstallations(jwtToken string) ([]installation, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, auth.FormatAPIStatusError(resp.StatusCode, body)
 	}
 
 	var installations []installation
@@ -370,7 +370,7 @@ func listInstallationRepositories(token, host string) ([]installationRepository,
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, auth.FormatAPIStatusError(resp.StatusCode, body)
 	}
 
 	var payload struct {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AmadeusITGroup/gh-app-auth/pkg/auth"
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/config"
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/jwt"
 	"github.com/AmadeusITGroup/gh-app-auth/pkg/secrets"
@@ -563,7 +564,7 @@ func findInstallationForOrg(jwtToken, host, org string) (int64, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return 0, fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(body))
+		return 0, auth.FormatAPIStatusError(resp.StatusCode, body)
 	}
 
 	var installations []struct {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -184,7 +184,7 @@ func testAPIAccess(token, repoURL string, verbose bool) error {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(body))
+		return auth.FormatAPIStatusError(resp.StatusCode, body)
 	}
 
 	// Parse response

--- a/pkg/auth/apierror.go
+++ b/pkg/auth/apierror.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// clockSkewHint is appended to GitHub 401 responses that indicate the JWT
+// timestamps were rejected. These failures are caused by the local clock
+// disagreeing with GitHub's, not by an invalid App configuration, so the raw
+// API message on its own tends to send users looking in the wrong place.
+const clockSkewHint = "the JWT timestamps were rejected because this machine's clock disagrees with GitHub's; " +
+	"synchronize the system clock (e.g. enable NTP on the host or container) and retry"
+
+// FormatAPIStatusError builds an error for a non-success GitHub API response,
+// adding actionable context for failure modes whose raw message is misleading.
+func FormatAPIStatusError(statusCode int, body []byte) error {
+	message := string(body)
+
+	if statusCode == http.StatusUnauthorized && isClockSkewMessage(message) {
+		return fmt.Errorf("GitHub API returned status %d: %s (%s)", statusCode, message, clockSkewHint)
+	}
+
+	return fmt.Errorf("GitHub API returned status %d: %s", statusCode, message)
+}
+
+// isClockSkewMessage reports whether a GitHub error body describes a JWT
+// timestamp rejection. GitHub phrases these as complaints about the 'exp' or
+// 'iat' claims.
+func isClockSkewMessage(message string) bool {
+	lower := strings.ToLower(message)
+
+	skewPhrases := []string{
+		"'exp') is too far in the future",
+		"'iat') is in the future",
+		"expiration time' claim ('exp') is too far in the future",
+		"issued at' claim ('iat') is in the future",
+	}
+
+	for _, phrase := range skewPhrases {
+		if strings.Contains(lower, strings.ToLower(phrase)) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/auth/apierror_test.go
+++ b/pkg/auth/apierror_test.go
@@ -1,0 +1,84 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestFormatAPIStatusError(t *testing.T) {
+	// The exact body GitHub returns when the local clock runs ahead of theirs.
+	clockSkewBody := `{"message":"'Expiration time' claim ('exp') is too far in the future",` +
+		`"documentation_url":"https://docs.github.com/rest","status":"401"}`
+
+	tests := []struct {
+		name     string
+		status   int
+		body     string
+		wantHint bool
+	}{
+		{"exp too far in the future", http.StatusUnauthorized, clockSkewBody, true},
+		{
+			"iat in the future",
+			http.StatusUnauthorized,
+			`{"message":"'Issued at' claim ('iat') is in the future","status":"401"}`,
+			true,
+		},
+		{
+			"unrelated 401",
+			http.StatusUnauthorized,
+			`{"message":"A JSON web token could not be decoded","status":"401"}`,
+			false,
+		},
+		{"not found", http.StatusNotFound, `{"message":"Not Found","status":"404"}`, false},
+		{"forbidden", http.StatusForbidden, `{"message":"Resource not accessible","status":"403"}`, false},
+		{"empty body", http.StatusUnauthorized, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := FormatAPIStatusError(tt.status, []byte(tt.body))
+			if err == nil {
+				t.Fatal("FormatAPIStatusError() returned nil, want error")
+			}
+
+			got := err.Error()
+
+			// The status code and the raw API body must always survive.
+			if !strings.Contains(got, tt.body) {
+				t.Errorf("error %q should contain the API body %q", got, tt.body)
+			}
+			if !strings.Contains(got, http.StatusText(tt.status)) && !strings.Contains(got, "status") {
+				t.Errorf("error %q should mention the status", got)
+			}
+
+			hasHint := strings.Contains(got, "synchronize the system clock")
+			if hasHint != tt.wantHint {
+				t.Errorf("clock skew hint present = %v, want %v (error: %q)", hasHint, tt.wantHint, got)
+			}
+		})
+	}
+}
+
+func TestIsClockSkewMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		want    bool
+	}{
+		{"exp claim", "'Expiration time' claim ('exp') is too far in the future", true},
+		{"iat claim", "'Issued at' claim ('iat') is in the future", true},
+		{"case insensitive", "'EXPIRATION TIME' CLAIM ('EXP') IS TOO FAR IN THE FUTURE", true},
+		{"bad credentials", "Bad credentials", false},
+		{"empty", "", false},
+		{"expired token", "token expired", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isClockSkewMessage(tt.message); got != tt.want {
+				t.Errorf("isClockSkewMessage(%q) = %v, want %v", tt.message, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -147,7 +147,7 @@ func (a *Authenticator) GetInstallationToken(jwtToken string, installationID int
 
 	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(body))
+		return "", FormatAPIStatusError(resp.StatusCode, body)
 	}
 
 	var tokenResponse struct {
@@ -200,7 +200,7 @@ func (a *Authenticator) findInstallationIDHTTP(jwtToken, host, repoURL string) (
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return 0, fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(body))
+		return 0, FormatAPIStatusError(resp.StatusCode, body)
 	}
 
 	var installation struct {

--- a/pkg/jwt/generator.go
+++ b/pkg/jwt/generator.go
@@ -17,6 +17,19 @@ import (
 	"time"
 )
 
+const (
+	// clockSkewTolerance backdates the 'iat' claim to tolerate a local clock that
+	// runs ahead of GitHub's. GitHub rejects JWTs whose 'iat' is in the future.
+	clockSkewTolerance = 60 * time.Second
+
+	// jwtValidity is the lifetime of the generated JWT. GitHub caps 'exp' at 10
+	// minutes ahead of *its own* clock and rejects anything beyond, so we stop at
+	// 9 minutes to leave a 60-second allowance for a local clock running fast.
+	// The JWT is only used to immediately mint an installation token, so the
+	// shorter lifetime costs nothing.
+	jwtValidity = 9 * time.Minute
+)
+
 type Generator struct {
 	// keyCache stores loaded keys in memory for the session
 	keyCache map[string]*rsa.PrivateKey
@@ -162,11 +175,19 @@ func (g *Generator) createJWT(issuer any, privateKey *rsa.PrivateKey) (string, e
 	}
 
 	// JWT Payload
+	//
+	// GitHub validates both claims against *its own* clock and rejects the JWT with
+	// HTTP 401 if 'iat' is in the future or 'exp' is more than 10 minutes ahead.
+	// Local clocks routinely drift by a few seconds (especially in containers and
+	// CI runners), so we deliberately leave margin on both ends instead of using
+	// the exact boundaries:
+	//   - 'iat' is backdated by clockSkewTolerance so a clock running ahead is fine.
+	//   - 'exp' uses jwtValidity (< 10 min) so a clock running ahead stays in range.
 	now := time.Now()
 	payload := map[string]interface{}{
 		"iss": issuer,
-		"iat": now.Unix(),
-		"exp": now.Add(10 * time.Minute).Unix(), // GitHub Apps tokens expire in 10 minutes max
+		"iat": now.Add(-clockSkewTolerance).Unix(),
+		"exp": now.Add(jwtValidity).Unix(),
 	}
 
 	// Encode header and payload

--- a/pkg/jwt/generator_integration_test.go
+++ b/pkg/jwt/generator_integration_test.go
@@ -288,13 +288,17 @@ func TestJWTExpiration(t *testing.T) {
 		t.Errorf("Expiration (%f) should be after issued time (%f)", exp, iat)
 	}
 
-	// Standard expiration is 10 minutes (600 seconds)
-	expectedDuration := float64(600)
+	// The exp-iat window is jwtValidity plus the clock-skew backdate applied to iat.
+	// It must stay at or under GitHub's 600-second maximum.
+	expectedDuration := (jwtValidity + clockSkewTolerance).Seconds()
 	actualDuration := exp - iat
 
-	// Allow some tolerance (595-605 seconds)
 	if actualDuration < expectedDuration-5 || actualDuration > expectedDuration+5 {
 		t.Errorf("Expected duration ~%f seconds, got %f", expectedDuration, actualDuration)
+	}
+
+	if actualDuration > 600 {
+		t.Errorf("exp-iat window is %f seconds, GitHub rejects anything over 600", actualDuration)
 	}
 }
 

--- a/pkg/jwt/generator_test.go
+++ b/pkg/jwt/generator_test.go
@@ -137,14 +137,26 @@ func TestGenerator_GenerateToken(t *testing.T) {
 					t.Errorf("Token iss claim = %v, want %v", claims["iss"], tt.appID)
 				}
 
-				// Verify timestamps
+				// Verify timestamps.
+				// 'iat' must be backdated to tolerate clock skew, and 'exp' must stay
+				// strictly under GitHub's 10-minute ceiling.
 				now := time.Now().Unix()
-				if iat, ok := claims["iat"].(float64); !ok || int64(iat) > now || int64(iat) < now-60 {
-					t.Errorf("Token iat claim = %v, should be around %v", claims["iat"], now)
+				iat, ok := claims["iat"].(float64)
+				if !ok || int64(iat) > now-1 || int64(iat) < now-int64(clockSkewTolerance.Seconds())-5 {
+					t.Errorf("Token iat claim = %v, should be backdated ~%vs before %v",
+						claims["iat"], clockSkewTolerance.Seconds(), now)
 				}
 
-				if exp, ok := claims["exp"].(float64); !ok || int64(exp) <= now || int64(exp) > now+600 {
+				exp, ok := claims["exp"].(float64)
+				if !ok || int64(exp) <= now || int64(exp) > now+600 {
 					t.Errorf("Token exp claim = %v, should be between %v and %v", claims["exp"], now, now+600)
+				}
+
+				// The window GitHub sees must remain under its 10-minute maximum even
+				// if our clock is ahead, which is what caused the "'exp' is too far in
+				// the future" 401.
+				if int64(exp)-now >= 600 {
+					t.Errorf("Token exp is %ds in the future, must be < 600s", int64(exp)-now)
 				}
 			}
 		})
@@ -512,9 +524,81 @@ func TestTokenExpiration(t *testing.T) {
 	iat := int64(claims["iat"].(float64))
 	exp := int64(claims["exp"].(float64))
 
-	// Verify expiration is exactly 10 minutes (600 seconds) after issued time
-	expectedExp := iat + 600
+	// 'iat' is backdated by clockSkewTolerance and 'exp' is jwtValidity ahead of
+	// generation time, so the window GitHub sees is the sum of the two.
+	expectedExp := iat + int64((jwtValidity + clockSkewTolerance).Seconds())
 	if exp != expectedExp {
-		t.Errorf("Token expiration = %v, want %v (10 minutes after iat)", exp, expectedExp)
+		t.Errorf("Token expiration = %v, want %v (%v after iat)", exp, expectedExp, jwtValidity+clockSkewTolerance)
 	}
+
+	// GitHub rejects a JWT whose 'exp' is more than 10 minutes ahead of its own
+	// clock, so the window must stay at or under 600 seconds to leave room for skew.
+	if window := exp - iat; window > 600 {
+		t.Errorf("exp-iat window is %ds, GitHub rejects anything over 600s", window)
+	}
+
+	// 'exp' must be in the future for the token to be usable at all.
+	if exp <= time.Now().Unix() {
+		t.Errorf("Token exp %v is not in the future", exp)
+	}
+}
+
+// TestJWTToleratesClockSkew is a regression test for the 401 GitHub returns when
+// the local clock runs ahead of its own:
+//
+//	'Expiration time' claim ('exp') is too far in the future
+//
+// GitHub validates 'exp' against its own clock and rejects anything more than
+// 600 seconds ahead. Setting exp to exactly now+600 left zero tolerance, so a
+// machine even one second fast (common in containers and CI runners) failed
+// every API call. Both claims must therefore carry margin.
+func TestJWTToleratesClockSkew(t *testing.T) {
+	generator := NewGenerator()
+	testKey, err := generateTestKey()
+	if err != nil {
+		t.Fatalf("Failed to generate test key: %v", err)
+	}
+
+	token, err := generator.GenerateTokenFromKey(int64(12345), encodePKCS1(t, testKey))
+	if err != nil {
+		t.Fatalf("Failed to generate token: %v", err)
+	}
+
+	claims, err := generator.GetTokenClaims(token)
+	if err != nil {
+		t.Fatalf("Failed to get claims: %v", err)
+	}
+
+	iat := int64(claims["iat"].(float64))
+	exp := int64(claims["exp"].(float64))
+
+	// Simulate GitHub's validation from a clock that lags behind ours. Each offset
+	// is how many seconds our clock is ahead of GitHub's.
+	for _, skewAhead := range []int64{0, 1, 5, 30, 60} {
+		githubNow := time.Now().Unix() - skewAhead
+
+		if exp-githubNow > 600 {
+			t.Errorf("clock %ds ahead: exp is %ds beyond GitHub's clock, exceeds the 600s maximum",
+				skewAhead, exp-githubNow)
+		}
+
+		if iat > githubNow {
+			t.Errorf("clock %ds ahead: iat %d is in the future relative to GitHub's clock %d",
+				skewAhead, iat, githubNow)
+		}
+
+		if exp <= githubNow {
+			t.Errorf("clock %ds ahead: exp %d is already expired against GitHub's clock %d",
+				skewAhead, exp, githubNow)
+		}
+	}
+}
+
+// encodePKCS1 returns the PEM-encoded PKCS1 representation of a private key.
+func encodePKCS1(t *testing.T, key *rsa.PrivateKey) string {
+	t.Helper()
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}))
 }


### PR DESCRIPTION
## Description

GitHub validates a GitHub App JWT's 'iat' and 'exp' claims against its own clock, rejecting 'exp' more than 600s ahead and any 'iat' in its future. The claims were generated at those exact boundaries, so a machine running even one second fast failed every API call with: `401 'Expiration time' claim ('exp') is too far in the future`

This broke authentication on hosts without a synchronised clock.

## Type of Change

Please delete options that are not relevant:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes, no api changes)
- [ ] ⚡ Performance improvements
- [x] 🧪 Test updates
- [ ] 🔒 Security improvements

## Changes Made

Add clockSkewTolerance (60s) to backdate 'iat' against a fast clock
Set jwtValidity to 9m so 'exp' stays 60s under GitHub's 600s cap
Add auth.FormatAPIStatusError() to annotate the timestamp 401 with a hint to synchronise the system clock

## Testing

Please describe the tests that you ran to verify your changes:

- [x] Unit tests pass: `go test ./...`
- [x] Build succeeds: `go build -o gh-app-auth .`
- [x] Manual testing performed
- [x] Integration tests with real GitHub Apps (if applicable)

### Test Configuration

- **OS**: Ubuntu
- **Go version**: 1.24.5
- **GitHub CLI version**: 2.88.0

## Security Considerations

If this PR involves security-related changes:

- [x] No sensitive data (tokens, keys) exposed in code or tests
- [ ] Input validation added/reviewed for new functionality  
- [x] Private key handling follows security best practices
- [x] Token caching security maintained
- [x] No new attack vectors introduced

## Documentation

- [x] Code comments updated
- [ ] README.md updated (if needed)
- [ ] Architecture documentation updated (if needed)
- [ ] Command help text updated (if needed)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] **Commit messages follow [Conventional Commits](https://github.com/AmadeusITGroup/gh-app-auth/blob/main/CONTRIBUTING.md#commit-message-guidelines) format**
- [x] **PR title follows conventional commits format** (e.g., `feat(auth): add token caching`)

## Breaking Changes

N/A

## Additional Notes

N/A